### PR TITLE
feat: add dropdown, date question types and expiration controls

### DIFF
--- a/app/api/surveys/[id]/public/route.ts
+++ b/app/api/surveys/[id]/public/route.ts
@@ -13,6 +13,10 @@ export async function GET(
       return Response.json({ error: "问卷不可用" }, { status: 404 });
     }
 
+    if (survey.expiresAt && Math.floor(Date.now() / 1000) > survey.expiresAt) {
+      return Response.json({ error: "问卷已过期" }, { status: 403 });
+    }
+
     return ok(survey);
   } catch (error) {
     return fromError(error);

--- a/app/surveys/[id]/fill/page.tsx
+++ b/app/surveys/[id]/fill/page.tsx
@@ -32,6 +32,17 @@ export default async function SurveyFillPage({
     notFound();
   }
 
+  if (survey.expiresAt && Math.floor(Date.now() / 1000) > survey.expiresAt && preview !== "1") {
+    return (
+      <main className="mx-auto flex min-h-screen max-w-3xl flex-col items-center justify-center px-6 text-center">
+        <h1 className="text-2xl font-semibold">问卷已过期</h1>
+        <p className="mt-2 text-slate-600">
+          该问卷已于 {new Date(survey.expiresAt * 1000).toLocaleDateString("zh-CN")} 截止。
+        </p>
+      </main>
+    );
+  }
+
   return (
     <main className="mx-auto max-w-3xl space-y-6 px-6 py-10">
       <header className="space-y-2">

--- a/components/survey-editor/component-palette.tsx
+++ b/components/survey-editor/component-palette.tsx
@@ -8,6 +8,8 @@ const MVP_TYPES: Array<{ type: QuestionType; label: string }> = [
   { type: "multiple_choice", label: "多选题" },
   { type: "text", label: "填空题" },
   { type: "rating", label: "评分题" },
+  { type: "dropdown", label: "下拉选择" },
+  { type: "date", label: "日期选择" },
 ];
 
 export function ComponentPalette({

--- a/components/survey-editor/editor-shell.tsx
+++ b/components/survey-editor/editor-shell.tsx
@@ -41,6 +41,7 @@ export function EditorShell({ survey }: { survey?: SurveyDetail | null }) {
       body: JSON.stringify({
         title: state.title,
         description: state.description,
+        expiresAt: state.expiresAt,
         questions: state.questions.map((question) => ({
           id: question.id,
           type: question.type,
@@ -90,6 +91,29 @@ export function EditorShell({ survey }: { survey?: SurveyDetail | null }) {
             dispatch({ type: "setDescription", value: event.target.value })
           }
         />
+        <div className="space-y-2">
+          <label className="text-sm font-medium" htmlFor="expires-at">
+            过期时间（可选）
+          </label>
+          <Input
+            id="expires-at"
+            type="date"
+            value={
+              state.expiresAt
+                ? new Date(state.expiresAt * 1000).toISOString().split("T")[0]
+                : ""
+            }
+            onChange={(event) => {
+              const dateValue = event.target.value;
+              dispatch({
+                type: "setExpiresAt",
+                value: dateValue
+                  ? Math.floor(new Date(dateValue).getTime() / 1000)
+                  : null,
+              });
+            }}
+          />
+        </div>
         <QuestionList
           questions={state.questions}
           selectedQuestionId={state.selectedQuestionId}

--- a/components/survey-editor/property-panel.tsx
+++ b/components/survey-editor/property-panel.tsx
@@ -40,7 +40,7 @@ export function PropertyPanel({
           onCheckedChange={(checked) => onChange({ required: checked })}
         />
       </div>
-      {(question.type === "single_choice" || question.type === "multiple_choice") &&
+      {(question.type === "single_choice" || question.type === "multiple_choice" || question.type === "dropdown") &&
       question.options.length > 0 ? (
         <div className="space-y-3">
           <Label>选项</Label>

--- a/components/survey-fill/question-field.tsx
+++ b/components/survey-fill/question-field.tsx
@@ -1,6 +1,13 @@
 "use client";
 
 import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
 import type {
   SurveyAnswerValue,
@@ -89,6 +96,23 @@ export function QuestionField({
           </label>
         ))}
       </div>
+    );
+  }
+
+  if (question.type === "dropdown") {
+    return (
+      <Select value={typeof value === "string" ? value : ""} onValueChange={(newValue) => onChange(newValue)}>
+        <SelectTrigger>
+          <SelectValue placeholder="请选择" />
+        </SelectTrigger>
+        <SelectContent>
+          {question.options.map((option) => (
+            <SelectItem key={option.value} value={option.value}>
+              {option.label}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
     );
   }
 

--- a/components/survey-fill/question-field.tsx
+++ b/components/survey-fill/question-field.tsx
@@ -116,6 +116,17 @@ export function QuestionField({
     );
   }
 
+  if (question.type === "date") {
+    return (
+      <Input
+        type="date"
+        value={typeof value === "string" ? value : ""}
+        onChange={(event) => onChange(event.target.value)}
+        aria-label={question.title}
+      />
+    );
+  }
+
   return (
     <div className="text-sm text-slate-500">
       当前题型待扩展

--- a/components/surveys/survey-list.tsx
+++ b/components/surveys/survey-list.tsx
@@ -19,6 +19,7 @@ export function SurveyList({
     title: string;
     status: string;
     createdAt: number;
+    expiresAt: number | null;
   }>;
 }) {
   return (
@@ -36,7 +37,14 @@ export function SurveyList({
           <TableRow key={survey.id}>
             <TableCell>{survey.title}</TableCell>
             <TableCell>
-              <Badge variant="secondary">{survey.status}</Badge>
+              <div className="flex flex-col gap-1">
+                <Badge variant="secondary">{survey.status}</Badge>
+                {survey.expiresAt ? (
+                  <span className="text-xs text-slate-500">
+                    到期：{new Date(survey.expiresAt * 1000).toLocaleDateString("zh-CN")}
+                  </span>
+                ) : null}
+              </div>
             </TableCell>
             <TableCell>
               {new Date(survey.createdAt * 1000).toLocaleString("zh-CN")}

--- a/docs/superpowers/plans/2026-04-26-dropdown-date-expiration.md
+++ b/docs/superpowers/plans/2026-04-26-dropdown-date-expiration.md
@@ -1,0 +1,919 @@
+# Dropdown, Date Question Types and Expiration Controls Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add dropdown and date question types to the survey platform, plus survey expiration time controls.
+
+**Architecture:** Frontend-focused changes to the editor (component palette, property panel, state management) and fill form (question renderer), plus lightweight backend expiration checks in the public API and submission service. Database schema and validators already support the new types.
+
+**Tech Stack:** Next.js 15, React 19, TypeScript, Tailwind CSS, shadcn/ui, Drizzle ORM, SQLite, Vitest, Playwright
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|------|--------|----------------|
+| `components/survey-editor/component-palette.tsx` | Modify | Add dropdown and date buttons to the editor palette |
+| `components/survey-editor/property-panel.tsx` | Modify | Enable option editing for dropdown questions |
+| `components/survey-editor/editor-shell.tsx` | Modify | Add expiresAt date picker to the editor |
+| `lib/surveys/editor-state.ts` | Modify | Add expiresAt to editor state and actions |
+| `components/survey-fill/question-field.tsx` | Modify | Render dropdown (Select) and date (input) fields |
+| `app/api/surveys/[id]/public/route.ts` | Modify | Reject requests for expired surveys |
+| `lib/surveys/response-service.ts` | Modify | Reject submissions for expired surveys |
+| `app/surveys/[id]/fill/page.tsx` | Modify | Render expiration notice for expired surveys |
+| `components/surveys/survey-list.tsx` | Modify | Show expiration badge in survey list |
+| `tests/components/question-field.test.tsx` | Create | Unit tests for dropdown and date rendering |
+| `tests/lib/validators.test.ts` | Create | Unit tests for answer validation |
+| `tests/e2e/fill-survey.spec.ts` | Modify | E2E test for filling dropdown/date surveys |
+| `tests/e2e/admin-crud.spec.ts` | Modify | E2E test for setting expiration time |
+| `tests/e2e/survey-expiration.spec.ts` | Create | E2E test for expired survey behavior |
+
+---
+
+### Task 1: Dropdown Editor Support
+
+**Files:**
+- Modify: `components/survey-editor/component-palette.tsx`
+- Modify: `components/survey-editor/property-panel.tsx`
+
+- [ ] **Step 1: Add dropdown to component palette**
+
+In `components/survey-editor/component-palette.tsx`, update `MVP_TYPES`:
+
+```tsx
+const MVP_TYPES: Array<{ type: QuestionType; label: string }> = [
+  { type: "single_choice", label: "单选题" },
+  { type: "multiple_choice", label: "多选题" },
+  { type: "text", label: "填空题" },
+  { type: "rating", label: "评分题" },
+  { type: "dropdown", label: "下拉选择" },
+  { type: "date", label: "日期选择" },
+];
+```
+
+- [ ] **Step 2: Enable option editing for dropdown in property panel**
+
+In `components/survey-editor/property-panel.tsx`, change the condition on line 43 from:
+
+```tsx
+{(question.type === "single_choice" || question.type === "multiple_choice") &&
+```
+
+to:
+
+```tsx
+{(question.type === "single_choice" || question.type === "multiple_choice" || question.type === "dropdown") &&
+```
+
+- [ ] **Step 3: Run lint and commit**
+
+```bash
+pnpm lint
+```
+
+```bash
+git add components/survey-editor/component-palette.tsx components/survey-editor/property-panel.tsx
+git commit -m "feat: add dropdown and date to editor palette and property panel"
+```
+
+---
+
+### Task 2: Dropdown Fill Form — TDD
+
+**Files:**
+- Create: `tests/components/question-field.test.tsx`
+- Modify: `components/survey-fill/question-field.tsx`
+
+- [ ] **Step 1: Write failing test for dropdown**
+
+Create `tests/components/question-field.test.tsx`:
+
+```tsx
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { QuestionField } from "@/components/survey-fill/question-field";
+import type { SurveyQuestionDetail } from "@/lib/surveys/types";
+
+describe("QuestionField", () => {
+  const dropdownQuestion: SurveyQuestionDetail = {
+    id: 1,
+    type: "dropdown",
+    title: "请选择城市",
+    required: false,
+    orderIndex: 0,
+    config: null,
+    options: [
+      { id: 1, label: "北京", value: "beijing", orderIndex: 0 },
+      { id: 2, label: "上海", value: "shanghai", orderIndex: 1 },
+    ],
+  };
+
+  it("renders dropdown options and calls onChange when selected", async () => {
+    const onChange = vi.fn();
+    render(<QuestionField question={dropdownQuestion} value={undefined} onChange={onChange} />);
+
+    const trigger = screen.getByRole("combobox");
+    await userEvent.click(trigger);
+
+    const option = screen.getByText("上海");
+    await userEvent.click(option);
+
+    expect(onChange).toHaveBeenCalledWith("shanghai");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+pnpm test tests/components/question-field.test.tsx
+```
+
+Expected: FAIL with "Unable to find role=\"combobox\"" because dropdown rendering is not yet implemented.
+
+- [ ] **Step 3: Implement dropdown rendering**
+
+In `components/survey-fill/question-field.tsx`, add before the final `return`:
+
+```tsx
+if (question.type === "dropdown") {
+  return (
+    <Select value={typeof value === "string" ? value : ""} onValueChange={onChange}>
+      <SelectTrigger>
+        <SelectValue placeholder="请选择" />
+      </SelectTrigger>
+      <SelectContent>
+        {question.options.map((option) => (
+          <SelectItem key={option.value} value={option.value}>
+            {option.label}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+}
+```
+
+Add imports at the top:
+
+```tsx
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+pnpm test tests/components/question-field.test.tsx
+```
+
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/components/question-field.test.tsx components/survey-fill/question-field.tsx
+git commit -m "feat: add dropdown question type rendering with tests"
+```
+
+---
+
+### Task 3: Date Fill Form — TDD
+
+**Files:**
+- Modify: `tests/components/question-field.test.tsx`
+- Modify: `components/survey-fill/question-field.tsx`
+
+- [ ] **Step 1: Write failing test for date**
+
+In `tests/components/question-field.test.tsx`, add:
+
+```tsx
+const dateQuestion: SurveyQuestionDetail = {
+  id: 2,
+  type: "date",
+  title: "请选择日期",
+  required: false,
+  orderIndex: 1,
+  config: null,
+  options: [],
+};
+
+it("renders date input and calls onChange when changed", async () => {
+  const onChange = vi.fn();
+  render(<QuestionField question={dateQuestion} value={undefined} onChange={onChange} />);
+
+  const input = screen.getByLabelText("请选择日期");
+  await userEvent.type(input, "2026-05-01");
+
+  expect(onChange).toHaveBeenCalledWith("2026-05-01");
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+pnpm test tests/components/question-field.test.tsx
+```
+
+Expected: FAIL with "Unable to find element with label text \"请选择日期\"" because date rendering is not yet implemented.
+
+- [ ] **Step 3: Implement date rendering**
+
+In `components/survey-fill/question-field.tsx`, add before the final `return`:
+
+```tsx
+if (question.type === "date") {
+  return (
+    <Input
+      type="date"
+      value={typeof value === "string" ? value : ""}
+      onChange={(event) => onChange(event.target.value)}
+      aria-label={question.title}
+    />
+  );
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+pnpm test tests/components/question-field.test.tsx
+```
+
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/components/question-field.test.tsx components/survey-fill/question-field.tsx
+git commit -m "feat: add date question type rendering with tests"
+```
+
+---
+
+### Task 4: Validators Unit Tests
+
+**Files:**
+- Create: `tests/lib/validators.test.ts`
+
+- [ ] **Step 1: Write validator tests**
+
+Create `tests/lib/validators.test.ts`:
+
+```tsx
+import { describe, expect, it } from "vitest";
+
+import { validateAnswersAgainstSurvey } from "@/lib/surveys/validators";
+import type { SurveyDetail } from "@/lib/surveys/types";
+
+function createSurvey(questions: SurveyDetail["questions"]): SurveyDetail {
+  return {
+    id: 1,
+    title: "测试问卷",
+    description: null,
+    status: "published",
+    expiresAt: null,
+    createdAt: 0,
+    updatedAt: 0,
+    questions,
+  };
+}
+
+describe("validateAnswersAgainstSurvey", () => {
+  it("accepts valid dropdown answer", () => {
+    const survey = createSurvey([
+      {
+        id: 1,
+        type: "dropdown",
+        title: "城市",
+        required: true,
+        orderIndex: 0,
+        config: null,
+        options: [{ id: 1, label: "北京", value: "beijing", orderIndex: 0 }],
+      },
+    ]);
+
+    expect(() =>
+      validateAnswersAgainstSurvey(survey, { question_1: "beijing" }),
+    ).not.toThrow();
+  });
+
+  it("rejects invalid dropdown answer", () => {
+    const survey = createSurvey([
+      {
+        id: 1,
+        type: "dropdown",
+        title: "城市",
+        required: true,
+        orderIndex: 0,
+        config: null,
+        options: [{ id: 1, label: "北京", value: "beijing", orderIndex: 0 }],
+      },
+    ]);
+
+    expect(() =>
+      validateAnswersAgainstSurvey(survey, { question_1: "shanghai" }),
+    ).toThrow("选择题答案格式错误");
+  });
+
+  it("accepts valid date answer", () => {
+    const survey = createSurvey([
+      {
+        id: 1,
+        type: "date",
+        title: "日期",
+        required: true,
+        orderIndex: 0,
+        config: null,
+        options: [],
+      },
+    ]);
+
+    expect(() =>
+      validateAnswersAgainstSurvey(survey, { question_1: "2026-05-01" }),
+    ).not.toThrow();
+  });
+
+  it("rejects non-string date answer", () => {
+    const survey = createSurvey([
+      {
+        id: 1,
+        type: "date",
+        title: "日期",
+        required: true,
+        orderIndex: 0,
+        config: null,
+        options: [],
+      },
+    ]);
+
+    expect(() =>
+      validateAnswersAgainstSurvey(survey, { question_1: 123 as unknown as string }),
+    ).toThrow("文本题答案格式错误");
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they pass**
+
+```bash
+pnpm test tests/lib/validators.test.ts
+```
+
+Expected: PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/lib/validators.test.ts
+git commit -m "test: add validator coverage for dropdown and date types"
+```
+
+---
+
+### Task 5: Expiration Time — Editor State
+
+**Files:**
+- Modify: `lib/surveys/editor-state.ts`
+
+- [ ] **Step 1: Add expiresAt to editor state**
+
+In `lib/surveys/editor-state.ts`:
+
+Update `EditorState`:
+
+```tsx
+export type EditorState = {
+  title: string;
+  description: string;
+  expiresAt: number | null;
+  questions: EditorQuestion[];
+  selectedQuestionId: string | null;
+};
+```
+
+Update `EditorAction`:
+
+```tsx
+export type EditorAction =
+  | { type: "setTitle"; value: string }
+  | { type: "setDescription"; value: string }
+  | { type: "setExpiresAt"; value: number | null }
+  | { type: "addQuestion"; questionType: QuestionType }
+  | { type: "selectQuestion"; clientId: string }
+  | { type: "moveQuestionUp"; clientId: string }
+  | { type: "updateQuestion"; clientId: string; patch: Partial<EditorQuestion> };
+```
+
+Update `createInitialEditorState`:
+
+```tsx
+export function createInitialEditorState(
+  survey?: SurveyDetail | null,
+): EditorState {
+  if (!survey) {
+    return {
+      title: "未命名问卷",
+      description: "",
+      expiresAt: null,
+      questions: [],
+      selectedQuestionId: null,
+    };
+  }
+
+  const questions = normalizeQuestionOrder(
+    survey.questions.map((question) => ({
+      ...question,
+      clientId: String(question.id),
+      config: question.config ?? null,
+      options: question.options ?? [],
+    })),
+  );
+
+  return {
+    title: survey.title,
+    description: survey.description ?? "",
+    expiresAt: survey.expiresAt,
+    questions,
+    selectedQuestionId: questions[0]?.clientId ?? null,
+  };
+}
+```
+
+Update `editorReducer`:
+
+```tsx
+case "setExpiresAt":
+  return { ...state, expiresAt: action.value };
+```
+
+- [ ] **Step 2: Run tests to ensure no regressions**
+
+```bash
+pnpm test
+```
+
+Expected: All existing tests pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add lib/surveys/editor-state.ts
+git commit -m "feat: add expiresAt to editor state management"
+```
+
+---
+
+### Task 6: Expiration Time — Editor UI
+
+**Files:**
+- Modify: `components/survey-editor/editor-shell.tsx`
+
+- [ ] **Step 1: Add expiresAt date picker to editor**
+
+In `components/survey-editor/editor-shell.tsx`, after the description `Textarea`, add:
+
+```tsx
+<div className="space-y-2">
+  <label className="text-sm font-medium" htmlFor="expires-at">
+    过期时间（可选）
+  </label>
+  <Input
+    id="expires-at"
+    type="date"
+    value={
+      state.expiresAt
+        ? new Date(state.expiresAt * 1000).toISOString().split("T")[0]
+        : ""
+    }
+    onChange={(event) => {
+      const dateValue = event.target.value;
+      dispatch({
+        type: "setExpiresAt",
+        value: dateValue
+          ? Math.floor(new Date(dateValue).getTime() / 1000)
+          : null,
+      });
+    }}
+  />
+</div>
+```
+
+Update `handleSave` to include `expiresAt`:
+
+```tsx
+body: JSON.stringify({
+  title: state.title,
+  description: state.description,
+  expiresAt: state.expiresAt,
+  questions: state.questions.map((question) => ({
+    id: question.id,
+    type: question.type,
+    title: question.title,
+    required: question.required,
+    orderIndex: question.orderIndex,
+    config: question.config ?? null,
+    options: question.options,
+  })),
+}),
+```
+
+- [ ] **Step 2: Run lint**
+
+```bash
+pnpm lint
+```
+
+Expected: No errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add components/survey-editor/editor-shell.tsx
+git commit -m "feat: add expiresAt date picker to survey editor"
+```
+
+---
+
+### Task 7: Expiration Time — Backend Checks
+
+**Files:**
+- Modify: `app/api/surveys/[id]/public/route.ts`
+- Modify: `lib/surveys/response-service.ts`
+
+- [ ] **Step 1: Add expiration check to public API**
+
+In `app/api/surveys/[id]/public/route.ts`, after the status check:
+
+```tsx
+if (!survey || survey.status !== "published") {
+  return Response.json({ error: "问卷不可用" }, { status: 404 });
+}
+
+if (survey.expiresAt && Math.floor(Date.now() / 1000) > survey.expiresAt) {
+  return Response.json({ error: "问卷已过期" }, { status: 403 });
+}
+```
+
+- [ ] **Step 2: Add expiration check to submission service**
+
+In `lib/surveys/response-service.ts`, after the status check:
+
+```tsx
+} else if (survey.status !== "published") {
+  throw new ApiError(409, "问卷尚未发布");
+}
+
+if (survey.expiresAt && Math.floor(Date.now() / 1000) > survey.expiresAt) {
+  throw new ApiError(403, "问卷已过期");
+}
+```
+
+- [ ] **Step 3: Run tests**
+
+```bash
+pnpm test
+```
+
+Expected: All existing tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/api/surveys/[id]/public/route.ts lib/surveys/response-service.ts
+git commit -m "feat: reject expired surveys in public API and submission"
+```
+
+---
+
+### Task 8: Expiration Time — Fill Page Notice
+
+**Files:**
+- Modify: `app/surveys/[id]/fill/page.tsx`
+
+- [ ] **Step 1: Render expiration notice for expired surveys**
+
+In `app/surveys/[id]/fill/page.tsx`, after the status check:
+
+```tsx
+if (survey.status !== "published" && preview !== "1") {
+  notFound();
+}
+
+if (survey.expiresAt && Math.floor(Date.now() / 1000) > survey.expiresAt && preview !== "1") {
+  return (
+    <main className="mx-auto flex min-h-screen max-w-3xl flex-col items-center justify-center px-6 text-center">
+      <h1 className="text-2xl font-semibold">问卷已过期</h1>
+      <p className="mt-2 text-slate-600">
+        该问卷已于 {new Date(survey.expiresAt * 1000).toLocaleDateString("zh-CN")} 截止。
+      </p>
+    </main>
+  );
+}
+```
+
+- [ ] **Step 2: Run lint**
+
+```bash
+pnpm lint
+```
+
+Expected: No errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/surveys/[id]/fill/page.tsx
+git commit -m "feat: show expiration notice on fill page for expired surveys"
+```
+
+---
+
+### Task 9: Survey List Expiration Badge
+
+**Files:**
+- Modify: `components/surveys/survey-list.tsx`
+
+- [ ] **Step 1: Show expiration info in survey list**
+
+In `components/surveys/survey-list.tsx`, update the props type:
+
+```tsx
+export function SurveyList({
+  surveys,
+}: {
+  surveys: Array<{
+    id: number;
+    title: string;
+    status: string;
+    createdAt: number;
+    expiresAt: number | null;
+  }>;
+}) {
+```
+
+Add an expiration column or modify the status cell. Replace the status cell with:
+
+```tsx
+<TableCell>
+  <div className="flex flex-col gap-1">
+    <Badge variant="secondary">{survey.status}</Badge>
+    {survey.expiresAt ? (
+      <span className="text-xs text-slate-500">
+        到期：{new Date(survey.expiresAt * 1000).toLocaleDateString("zh-CN")}
+      </span>
+    ) : null}
+  </div>
+</TableCell>
+```
+
+- [ ] **Step 2: Run lint**
+
+```bash
+pnpm lint
+```
+
+Expected: No errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add components/surveys/survey-list.tsx
+git commit -m "feat: show expiration date in survey list"
+```
+
+---
+
+### Task 10: E2E Tests
+
+**Files:**
+- Modify: `tests/e2e/fill-survey.spec.ts`
+- Modify: `tests/e2e/admin-crud.spec.ts`
+- Create: `tests/e2e/survey-expiration.spec.ts`
+
+- [ ] **Step 1: Extend fill-survey E2E test**
+
+In `tests/e2e/fill-survey.spec.ts`, add a new test:
+
+```tsx
+test("public user can fill dropdown and date questions", async ({ browser, page }) => {
+  const surveyId = await createPublishedSurvey(page);
+
+  // Add dropdown and date questions via API
+  await page.evaluate(async (id) => {
+    await fetch(`/api/surveys/${id}`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        title: "测试问卷",
+        questions: [
+          {
+            type: "dropdown",
+            title: "请选择城市",
+            required: true,
+            orderIndex: 0,
+            config: null,
+            options: [
+              { label: "北京", value: "beijing", orderIndex: 0 },
+              { label: "上海", value: "shanghai", orderIndex: 1 },
+            ],
+          },
+          {
+            type: "date",
+            title: "请选择日期",
+            required: true,
+            orderIndex: 1,
+            config: null,
+            options: [],
+          },
+        ],
+      }),
+    });
+  }, surveyId);
+
+  const publicContext = await browser.newContext();
+  const publicPage = await publicContext.newPage();
+
+  await publicPage.goto(`/surveys/${surveyId}/fill`);
+
+  // Fill dropdown
+  await publicPage.getByRole("combobox").click();
+  await publicPage.getByText("上海").click();
+
+  // Fill date
+  await publicPage.getByLabel("请选择日期").fill("2026-05-01");
+
+  await publicPage.getByRole("button", { name: "提交问卷" }).click();
+  await expect(publicPage.getByText("感谢你的填写")).toBeVisible();
+
+  await publicContext.close();
+});
+```
+
+- [ ] **Step 2: Extend admin-crud E2E test**
+
+In `tests/e2e/admin-crud.spec.ts`, add expiration time setting:
+
+```tsx
+test("admin can set expiration time when creating survey", async ({ page }) => {
+  await page.goto("/login");
+  await page.getByLabel("用户名").fill(process.env.E2E_ADMIN_USERNAME ?? "admin");
+  await page.getByLabel("密码").fill(process.env.E2E_ADMIN_PASSWORD ?? "secret123");
+  await page.getByRole("button", { name: "登录" }).click();
+
+  await page.getByRole("link", { name: "新建问卷" }).click();
+  await page.locator("input").first().fill("带过期时间的问卷");
+
+  // Set expiration date (tomorrow)
+  const tomorrow = new Date();
+  tomorrow.setDate(tomorrow.getDate() + 1);
+  const dateString = tomorrow.toISOString().split("T")[0];
+  await page.getByLabel("过期时间").fill(dateString);
+
+  await page.getByRole("button", { name: "保存" }).click();
+  await expect(page.getByText("问卷已保存")).toBeVisible();
+
+  // Verify expiration is shown in list
+  await page.goto("/surveys");
+  await expect(page.getByText(`到期：${tomorrow.toLocaleDateString("zh-CN")}`)).toBeVisible();
+});
+```
+
+- [ ] **Step 3: Create expiration E2E test**
+
+Create `tests/e2e/survey-expiration.spec.ts`:
+
+```tsx
+import { expect, test } from "@playwright/test";
+
+test("expired survey cannot be accessed publicly", async ({ page }) => {
+  // Create and publish a survey with past expiration date via API
+  const response = await page.request.post("/api/surveys", {
+    headers: { "Cookie": process.env.E2E_ADMIN_COOKIE ?? "" },
+    data: {
+      title: "过期问卷",
+      expiresAt: Math.floor(Date.now() / 1000) - 86400, // yesterday
+      questions: [
+        {
+          type: "text",
+          title: "姓名",
+          required: true,
+          orderIndex: 0,
+          config: null,
+          options: [],
+        },
+      ],
+    },
+  });
+
+  expect(response.ok()).toBeTruthy();
+  const { data } = await response.json();
+  const surveyId = data.id;
+
+  // Publish it
+  await page.request.post(`/api/surveys/${surveyId}/publish`, {
+    data: { status: "published" },
+  });
+
+  // Try to access fill page
+  await page.goto(`/surveys/${surveyId}/fill`);
+  await expect(page.getByText("问卷已过期")).toBeVisible();
+});
+
+test("expired survey cannot be submitted", async ({ page }) => {
+  // Create survey with past expiration
+  const response = await page.request.post("/api/surveys", {
+    headers: { "Cookie": process.env.E2E_ADMIN_COOKIE ?? "" },
+    data: {
+      title: "过期问卷",
+      expiresAt: Math.floor(Date.now() / 1000) - 86400,
+      questions: [
+        {
+          type: "text",
+          title: "姓名",
+          required: false,
+          orderIndex: 0,
+          config: null,
+          options: [],
+        },
+      ],
+    },
+  });
+
+  const { data } = await response.json();
+  const surveyId = data.id;
+
+  await page.request.post(`/api/surveys/${surveyId}/publish`, {
+    data: { status: "published" },
+  });
+
+  // Try to submit directly via API
+  const submitResponse = await page.request.post(`/api/surveys/${surveyId}/responses`, {
+    data: {
+      answers: { question_1: "test" },
+      respondent_id: "test-respondent",
+      duration_seconds: 10,
+    },
+  });
+
+  expect(submitResponse.status()).toBe(403);
+  const body = await submitResponse.json();
+  expect(body.error).toBe("问卷已过期");
+});
+```
+
+Note: The E2E tests above use direct API calls. If `E2E_ADMIN_COOKIE` is not set, you may need to log in via UI first in a `test.beforeEach` or helper. Adjust based on existing test infrastructure.
+
+- [ ] **Step 4: Run E2E tests**
+
+```bash
+pnpm test:e2e
+```
+
+Expected: All E2E tests pass (including new ones).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/e2e/
+git commit -m "test: add E2E coverage for dropdown, date, and expiration"
+```
+
+---
+
+## Self-Review Checklist
+
+**1. Spec coverage:**
+- [x] Dropdown question type in editor (Task 1, 2)
+- [x] Date question type in editor (Task 1 — palette, Task 4 — fill form)
+- [x] Dropdown rendering with Select component (Task 2)
+- [x] Date rendering with date input (Task 4)
+- [x] ExpiresAt in editor state (Task 5)
+- [x] ExpiresAt date picker in editor UI (Task 6)
+- [x] Public API expiration check (Task 7)
+- [x] Submission service expiration check (Task 7)
+- [x] Fill page expiration notice (Task 8)
+- [x] Survey list expiration badge (Task 9)
+- [x] Unit tests for question-field (Tasks 2, 4)
+- [x] Unit tests for validators (Task 4)
+- [x] E2E tests (Task 10)
+
+**2. Placeholder scan:**
+- [x] No TBD, TODO, or "implement later" found
+- [x] Every step contains actual code or exact commands
+- [x] No vague instructions like "add appropriate error handling"
+
+**3. Type consistency:**
+- [x] `expiresAt` is consistently `number | null` (Unix seconds)
+- [x] `dropdown` answer type is consistently `string`
+- [x] `date` answer type is consistently `string` (`YYYY-MM-DD`)
+- [x] `QuestionType` values match schema enum

--- a/docs/superpowers/specs/2026-04-26-dropdown-date-expiration-design.md
+++ b/docs/superpowers/specs/2026-04-26-dropdown-date-expiration-design.md
@@ -1,0 +1,176 @@
+# 夯实核心体验（第一批）— 设计文档
+
+## 1. 背景与目标
+
+Juanbing MVP 已支持单选、多选、填空、评分四种基础题型，以及问卷的创建、发布、填写和结果查看。为了扩展问卷的适用场景，第一批聚焦补齐两种常用题型（下拉选择、日期选择）和过期时间控制，使平台能覆盖更多数据收集需求。
+
+## 2. 范围
+
+本次实现包含以下三个功能点：
+
+| 功能点 | 复杂度 | 说明 |
+|--------|--------|------|
+| 下拉选择题型 | 低 | 复用现有选项模型，前端增加 Select 渲染 |
+| 日期选择题型 | 低 | 前端增加 date input 渲染，答案为 `YYYY-MM-DD` 字符串 |
+| 问卷过期时间控制 | 低 | 编辑器支持设置 `expiresAt`，公开接口校验过期状态 |
+
+**不包含的内容**：矩阵题、逻辑跳转、数据可视化图表、Excel 导出。
+
+## 3. 架构概览
+
+本次改动以**前端补齐为主**，后端基础设施（schema、校验器、repository）已完全支持，仅需增加过期校验逻辑。
+
+```
+编辑器（EditorShell / ComponentPalette / PropertyPanel）
+    ↓ 保存
+API（/api/surveys, /api/surveys/[id]）— validators.ts 已支持
+    ↓
+数据库（surveys.expiresAt, surveyQuestions.type: dropdown|date）
+
+填写端（/surveys/[id]/fill）
+    ← 获取问卷（public API 校验 expiresAt）
+    ← 提交响应（response-service 校验 expiresAt）
+    QuestionField 渲染 dropdown / date
+```
+
+## 4. 模块详细设计
+
+### 4.1 题型扩展 — 下拉选择（dropdown）
+
+#### 编辑器侧
+
+- **ComponentPalette**：在 `MVP_TYPES` 中追加 `{ type: "dropdown", label: "下拉选择" }`。默认问题创建逻辑已存在（`question-defaults.ts`），会自动生成 2 个默认选项。
+- **PropertyPanel**：`dropdown` 的选项编辑逻辑与单选/多选完全一致。将现有条件 `(question.type === "single_choice" || question.type === "multiple_choice")` 扩展为包含 `"dropdown"`。
+
+#### 填写侧
+
+- **QuestionField**：新增 `dropdown` 分支，使用 `components/ui/select.tsx` 中的 `Select` 组件渲染。选项数据来自 `question.options`，答案值为单个字符串（选中选项的 `value`）。
+
+#### 校验
+
+- 后端 `validators.ts` 中 `choiceQuestionSchema` 已包含 `"dropdown"`，`validateChoiceQuestion` 已处理该类型的答案合法性校验。
+
+### 4.2 题型扩展 — 日期选择（date）
+
+#### 编辑器侧
+
+- **ComponentPalette**：在 `MVP_TYPES` 中追加 `{ type: "date", label: "日期选择" }`。默认问题创建逻辑已存在。
+- **PropertyPanel**：`date` 无需特殊属性配置，当前面板（题目标题 + 必填开关）已足够。
+
+#### 填写侧
+
+- **QuestionField**：新增 `date` 分支，使用原生 `<input type="date">` 渲染。答案值为 `YYYY-MM-DD` 格式字符串。
+
+#### 校验
+
+- 后端 `validators.ts` 中 `dateQuestionSchema` 已存在，`validateAnswersAgainstSurvey` 中 `date` 走 `validateTextLikeQuestion`（校验值为字符串类型）。
+
+### 4.3 过期时间控制
+
+#### 编辑器侧
+
+- **EditorShell**：在问卷标题/描述输入下方增加 `expiresAt` 日期选择器（`<input type="date">`）。
+- **状态管理**：
+  - `EditorState` 新增 `expiresAt: number | null`（Unix 秒级时间戳，与数据库一致）。
+  - `EditorAction` 新增 `{ type: "setExpiresAt"; value: number | null }`。
+  - `createInitialEditorState` 从 `survey.expiresAt` 初始化。
+- **保存**：`handleSave` 中将 `state.expiresAt` 随请求体发送。`validators.ts:surveyInputSchema` 已接受 `expiresAt: number.int().nullable().optional()`。
+
+#### 后端校验
+
+- **公开获取问卷**（`app/api/surveys/[id]/public/route.ts`）：
+  - 在 `survey.status !== "published"` 校验之后，追加 `expiresAt` 校验。
+  - 若 `survey.expiresAt` 存在且当前 Unix 时间 > `expiresAt`，返回 `403` 状态码，`{ error: "问卷已过期" }`。
+- **提交响应**（`lib/surveys/response-service.ts`）：
+  - 在正式提交前校验 `expiresAt`，过期则抛出 `ApiError(403, "问卷已过期")`。
+  - 预览模式不受过期限制。
+
+#### 填写侧
+
+- **填写页服务端预检**（`app/surveys/[id]/fill/page.tsx`）：
+  - 在获取问卷后、渲染表单前，校验 `expiresAt`。
+  - 若已过期，渲染静态过期提示页面（无需加载客户端表单）。
+  - 预览模式（`?preview=1`）跳过过期校验。
+
+#### 管理端展示（可选增强）
+
+- **问卷列表**（`components/surveys/survey-list.tsx`）：若问卷已设置 `expiresAt`，在卡片上显示过期日期标签（例如 "2026-05-01 到期"）。过期问卷视觉上以灰色或警告色区分。
+
+## 5. 数据流
+
+### 创建/编辑含新题型的问卷
+
+```
+用户点击 ComponentPalette "下拉选择" / "日期选择"
+  → editorReducer 创建默认问题（含默认选项/配置）
+  → 用户在 PropertyPanel 编辑标题、选项（dropdown）、必填状态
+  → 用户点击保存
+  → EditorShell 组装 { title, description, expiresAt, questions }
+  → POST/PUT /api/surveys
+  → validators.ts 校验（dropdown 走 choiceQuestionSchema，date 走 dateQuestionSchema）
+  → repository.ts 写入 surveys + surveyQuestions + surveyOptions
+```
+
+### 用户填写含新题型的问卷
+
+```
+访问 /surveys/:id/fill
+  → fill/page.tsx 获取问卷
+  → 校验 expiresAt（未过期则继续，已过期则显示过期页）
+  → SurveyFillPageClient 渲染 QuestionField
+     → dropdown: Select 组件
+     → date: input type="date"
+  → 用户提交
+  → POST /api/surveys/:id/responses
+  → response-service 校验 expiresAt + validateAnswersAgainstSurvey
+  → 数据入库
+```
+
+## 6. 错误处理
+
+| 场景 | 行为 |
+|------|------|
+| 过期问卷被公开访问 | 返回 403 `"问卷已过期"`，前端显示友好提示页 |
+| 过期问卷被提交 | 返回 403 `"问卷已过期"` |
+| dropdown 答案包含非法选项 | 返回 400 `"选择题答案格式错误"`（现有行为） |
+| date 答案非字符串 | 返回 400 `"文本题答案格式错误"`（现有行为） |
+| 必填 dropdown/date 未作答 | 前端拦截（现有行为），后端兜底返回 400 |
+
+## 7. 测试策略
+
+### 7.1 单元测试（Vitest）
+
+- **`tests/components/question-field.test.tsx`**（新增）：
+  - `dropdown`：渲染 Select，选择选项后 `onChange` 被正确调用。
+  - `date`：渲染 date input，输入 `2026-05-01` 后 `onChange` 被正确调用。
+- **`tests/lib/validators.test.ts`**（新增或补充）：
+  - `dropdown` 答案校验：合法选项通过，非法选项报错，空值在必填时报错。
+  - `date` 答案校验：字符串通过，非字符串报错，空值在必填时报错。
+
+### 7.2 E2E 测试（Playwright）
+
+- **`tests/e2e/fill-survey.spec.ts`**（扩展）：
+  - 管理员创建含 `dropdown` 和 `date` 的问卷 → 发布 → 匿名用户填写并提交 → 提交成功。
+- **`tests/e2e/admin-crud.spec.ts`**（扩展）：
+  - 创建问卷时设置 `expiresAt`，保存后在列表中正确显示过期日期。
+
+### 7.3 过期时间专项测试
+
+- **`tests/e2e/survey-expiration.spec.ts`**（新增）：
+  - 过期问卷公开访问返回 403，显示"问卷已过期"。
+  - 未过期问卷正常填写。
+  - 预览模式下过期问卷仍可访问和填写。
+
+### 7.4 回归测试清单
+
+- [ ] 现有 4 种题型（单选、多选、填空、评分）的创建/填写/结果查看不受影响。
+- [ ] CSV 导出包含新题型的答案（dropdown 导出为字符串，date 导出为日期字符串）。
+- [ ] 结果看板正常显示含新题型的问卷数据。
+
+## 8. 验收标准
+
+- [ ] 管理员可以在编辑器中创建含下拉选择和日期选择的问卷，并设置过期时间。
+- [ ] 下拉选择和日期选择在公开填写页正常渲染和提交。
+- [ ] 已过期的问卷无法被公开访问和提交，显示"问卷已过期"提示。
+- [ ] 预览模式不受过期时间限制。
+- [ ] 所有现有测试通过，新增测试覆盖新功能。

--- a/lib/surveys/editor-state.ts
+++ b/lib/surveys/editor-state.ts
@@ -17,6 +17,7 @@ export type EditorQuestion = SurveyInput["questions"][number] & {
 export type EditorState = {
   title: string;
   description: string;
+  expiresAt: number | null;
   questions: EditorQuestion[];
   selectedQuestionId: string | null;
 };
@@ -24,6 +25,7 @@ export type EditorState = {
 export type EditorAction =
   | { type: "setTitle"; value: string }
   | { type: "setDescription"; value: string }
+  | { type: "setExpiresAt"; value: number | null }
   | { type: "addQuestion"; questionType: QuestionType }
   | { type: "selectQuestion"; clientId: string }
   | { type: "moveQuestionUp"; clientId: string }
@@ -47,6 +49,7 @@ export function createInitialEditorState(
     return {
       title: "未命名问卷",
       description: "",
+      expiresAt: null,
       questions: [],
       selectedQuestionId: null,
     };
@@ -64,6 +67,7 @@ export function createInitialEditorState(
   return {
     title: survey.title,
     description: survey.description ?? "",
+    expiresAt: survey.expiresAt,
     questions,
     selectedQuestionId: questions[0]?.clientId ?? null,
   };
@@ -75,6 +79,8 @@ export function editorReducer(state: EditorState, action: EditorAction) {
       return { ...state, title: action.value };
     case "setDescription":
       return { ...state, description: action.value };
+    case "setExpiresAt":
+      return { ...state, expiresAt: action.value };
     case "addQuestion": {
       const clientId = generateUUID();
       const question = {

--- a/lib/surveys/response-service.ts
+++ b/lib/surveys/response-service.ts
@@ -55,6 +55,10 @@ export async function submitSurveyResponse({
     throw new ApiError(409, "问卷尚未发布");
   }
 
+  if (survey.expiresAt && Math.floor(Date.now() / 1000) > survey.expiresAt) {
+    throw new ApiError(403, "问卷已过期");
+  }
+
   validateAnswersAgainstSurvey(survey, parsed.answers);
 
   const answers = Object.fromEntries(

--- a/tests/components/question-field.test.tsx
+++ b/tests/components/question-field.test.tsx
@@ -31,4 +31,24 @@ describe("QuestionField", () => {
 
     expect(onChange).toHaveBeenCalledWith("shanghai");
   });
+
+  const dateQuestion: SurveyQuestionDetail = {
+    id: 2,
+    type: "date",
+    title: "请选择日期",
+    required: false,
+    orderIndex: 1,
+    config: null,
+    options: [],
+  };
+
+  it("renders date input and calls onChange when changed", async () => {
+    const onChange = vi.fn();
+    render(<QuestionField question={dateQuestion} value={undefined} onChange={onChange} />);
+
+    const input = screen.getByLabelText("请选择日期");
+    await userEvent.type(input, "2026-05-01");
+
+    expect(onChange).toHaveBeenCalledWith("2026-05-01");
+  });
 });

--- a/tests/components/question-field.test.tsx
+++ b/tests/components/question-field.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { QuestionField } from "@/components/survey-fill/question-field";
+import type { SurveyQuestionDetail } from "@/lib/surveys/types";
+
+describe("QuestionField", () => {
+  const dropdownQuestion: SurveyQuestionDetail = {
+    id: 1,
+    type: "dropdown",
+    title: "请选择城市",
+    required: false,
+    orderIndex: 0,
+    config: null,
+    options: [
+      { id: 1, label: "北京", value: "beijing", orderIndex: 0 },
+      { id: 2, label: "上海", value: "shanghai", orderIndex: 1 },
+    ],
+  };
+
+  it("renders dropdown options and calls onChange when selected", async () => {
+    const onChange = vi.fn();
+    render(<QuestionField question={dropdownQuestion} value={undefined} onChange={onChange} />);
+
+    const trigger = screen.getByRole("combobox");
+    await userEvent.click(trigger);
+
+    const option = screen.getByText("上海");
+    await userEvent.click(option);
+
+    expect(onChange).toHaveBeenCalledWith("shanghai");
+  });
+});

--- a/tests/e2e/admin-crud.spec.ts
+++ b/tests/e2e/admin-crud.spec.ts
@@ -15,3 +15,29 @@ test("admin can login and create a survey", async ({ page }) => {
   await expect(page.getByText("问卷已保存")).toBeVisible();
   await expect(page).toHaveURL(/\/surveys\/\d+$/);
 });
+
+test("admin can set expiration time when creating survey", async ({ page }) => {
+  await page.goto("/login");
+  await page.getByLabel("用户名").fill(process.env.E2E_ADMIN_USERNAME ?? "admin");
+  await page.getByLabel("密码").fill(process.env.E2E_ADMIN_PASSWORD ?? "secret123");
+  await page.getByRole("button", { name: "登录" }).click();
+
+  await page.getByRole("link", { name: "新建问卷" }).click();
+  await page.locator("input").first().fill("带过期时间的问卷");
+
+  // Add a question first (required before saving)
+  await page.getByRole("button", { name: "填空题" }).click();
+
+  // Set expiration date (tomorrow)
+  const tomorrow = new Date();
+  tomorrow.setDate(tomorrow.getDate() + 1);
+  const dateString = tomorrow.toISOString().split("T")[0];
+  await page.getByLabel("过期时间（可选）").fill(dateString);
+
+  await page.getByRole("button", { name: "保存" }).click();
+  await expect(page.getByText("问卷已保存")).toBeVisible();
+
+  // Verify expiration is shown in list
+  await page.goto("/surveys");
+  await expect(page.getByText(`到期：${tomorrow.toLocaleDateString("zh-CN")}`).first()).toBeVisible();
+});

--- a/tests/e2e/fill-survey.spec.ts
+++ b/tests/e2e/fill-survey.spec.ts
@@ -26,6 +26,59 @@ async function createPublishedSurvey(page: import("@playwright/test").Page) {
   return surveyId!;
 }
 
+test("public user can fill dropdown and date questions", async ({ browser, page }) => {
+  const surveyId = await createPublishedSurvey(page);
+
+  // Add dropdown and date questions via API
+  await page.evaluate(async (id) => {
+    await fetch(`/api/surveys/${id}`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        title: "测试问卷",
+        questions: [
+          {
+            type: "dropdown",
+            title: "请选择城市",
+            required: true,
+            orderIndex: 0,
+            config: null,
+            options: [
+              { label: "北京", value: "beijing", orderIndex: 0 },
+              { label: "上海", value: "shanghai", orderIndex: 1 },
+            ],
+          },
+          {
+            type: "date",
+            title: "请选择日期",
+            required: true,
+            orderIndex: 1,
+            config: null,
+            options: [],
+          },
+        ],
+      }),
+    });
+  }, surveyId);
+
+  const publicContext = await browser.newContext();
+  const publicPage = await publicContext.newPage();
+
+  await publicPage.goto(`/surveys/${surveyId}/fill`);
+
+  // Fill dropdown
+  await publicPage.getByRole("combobox").click();
+  await publicPage.getByText("上海").click();
+
+  // Fill date
+  await publicPage.getByLabel("请选择日期").fill("2026-05-01");
+
+  await publicPage.getByRole("button", { name: "提交问卷" }).click();
+  await expect(publicPage.getByText("感谢你的填写")).toBeVisible();
+
+  await publicContext.close();
+});
+
 test("public user can submit only once", async ({ browser, page }) => {
   const surveyId = await createPublishedSurvey(page);
   const publicContext = await browser.newContext();

--- a/tests/e2e/survey-expiration.spec.ts
+++ b/tests/e2e/survey-expiration.spec.ts
@@ -1,0 +1,95 @@
+import { expect, test } from "@playwright/test";
+
+async function getAdminCookie(page: import("@playwright/test").Page): Promise<string> {
+  await page.goto("/login");
+  await page.getByLabel("用户名").fill(process.env.E2E_ADMIN_USERNAME ?? "admin");
+  await page.getByLabel("密码").fill(process.env.E2E_ADMIN_PASSWORD ?? "secret123");
+  await page.getByRole("button", { name: "登录" }).click();
+  await expect(page).toHaveURL(/\/surveys$/);
+
+  const cookies = await page.context().cookies();
+  const sessionCookie = cookies.find((c) => c.name === "juanbing_admin_session");
+  expect(sessionCookie).toBeTruthy();
+  return `juanbing_admin_session=${sessionCookie!.value}`;
+}
+
+test("expired survey cannot be accessed publicly", async ({ page }) => {
+  const cookie = await getAdminCookie(page);
+
+  // Create and publish a survey with past expiration date via API
+  const response = await page.request.post("/api/surveys", {
+    headers: { "Cookie": cookie },
+    data: {
+      title: "过期问卷",
+      expiresAt: Math.floor(Date.now() / 1000) - 86400, // yesterday
+      questions: [
+        {
+          type: "text",
+          title: "姓名",
+          required: true,
+          orderIndex: 0,
+          config: null,
+          options: [],
+        },
+      ],
+    },
+  });
+
+  expect(response.ok()).toBeTruthy();
+  const { data } = await response.json();
+  const surveyId = data.id;
+
+  // Publish it
+  await page.request.post(`/api/surveys/${surveyId}/publish`, {
+    headers: { "Cookie": cookie },
+    data: { status: "published" },
+  });
+
+  // Try to access fill page
+  await page.goto(`/surveys/${surveyId}/fill`);
+  await expect(page.getByText("问卷已过期")).toBeVisible();
+});
+
+test("expired survey cannot be submitted", async ({ page }) => {
+  const cookie = await getAdminCookie(page);
+
+  // Create survey with past expiration
+  const response = await page.request.post("/api/surveys", {
+    headers: { "Cookie": cookie },
+    data: {
+      title: "过期问卷",
+      expiresAt: Math.floor(Date.now() / 1000) - 86400,
+      questions: [
+        {
+          type: "text",
+          title: "姓名",
+          required: false,
+          orderIndex: 0,
+          config: null,
+          options: [],
+        },
+      ],
+    },
+  });
+
+  const { data } = await response.json();
+  const surveyId = data.id;
+
+  await page.request.post(`/api/surveys/${surveyId}/publish`, {
+    headers: { "Cookie": cookie },
+    data: { status: "published" },
+  });
+
+  // Try to submit directly via API
+  const submitResponse = await page.request.post(`/api/surveys/${surveyId}/responses`, {
+    data: {
+      answers: { question_1: "test" },
+      respondent_id: "test-respondent",
+      duration_seconds: 10,
+    },
+  });
+
+  expect(submitResponse.status()).toBe(403);
+  const body = await submitResponse.json();
+  expect(body.error).toBe("问卷已过期");
+});

--- a/tests/lib/surveys/validators.test.ts
+++ b/tests/lib/surveys/validators.test.ts
@@ -7,6 +7,19 @@ import {
 } from "@/lib/surveys/validators";
 import type { SurveyDetail } from "@/lib/surveys/types";
 
+function createSurvey(questions: SurveyDetail["questions"]): SurveyDetail {
+  return {
+    id: 1,
+    title: "测试问卷",
+    description: null,
+    status: "published",
+    expiresAt: null,
+    createdAt: 0,
+    updatedAt: 0,
+    questions,
+  };
+}
+
 describe("survey validators", () => {
   it("accepts a valid survey draft", () => {
     const result = surveyInputSchema.safeParse({
@@ -79,5 +92,79 @@ describe("survey validators", () => {
     expect(() =>
       validateAnswersAgainstSurvey(survey, { question_11: "" }),
     ).toThrow(/你的姓名/);
+  });
+});
+
+describe("validateAnswersAgainstSurvey", () => {
+  it("accepts valid dropdown answer", () => {
+    const survey = createSurvey([
+      {
+        id: 1,
+        type: "dropdown",
+        title: "城市",
+        required: true,
+        orderIndex: 0,
+        config: null,
+        options: [{ id: 1, label: "北京", value: "beijing", orderIndex: 0 }],
+      },
+    ]);
+
+    expect(() =>
+      validateAnswersAgainstSurvey(survey, { question_1: "beijing" }),
+    ).not.toThrow();
+  });
+
+  it("rejects invalid dropdown answer", () => {
+    const survey = createSurvey([
+      {
+        id: 1,
+        type: "dropdown",
+        title: "城市",
+        required: true,
+        orderIndex: 0,
+        config: null,
+        options: [{ id: 1, label: "北京", value: "beijing", orderIndex: 0 }],
+      },
+    ]);
+
+    expect(() =>
+      validateAnswersAgainstSurvey(survey, { question_1: "shanghai" }),
+    ).toThrow("选择题答案格式错误");
+  });
+
+  it("accepts valid date answer", () => {
+    const survey = createSurvey([
+      {
+        id: 1,
+        type: "date",
+        title: "日期",
+        required: true,
+        orderIndex: 0,
+        config: null,
+        options: [],
+      },
+    ]);
+
+    expect(() =>
+      validateAnswersAgainstSurvey(survey, { question_1: "2026-05-01" }),
+    ).not.toThrow();
+  });
+
+  it("rejects non-string date answer", () => {
+    const survey = createSurvey([
+      {
+        id: 1,
+        type: "date",
+        title: "日期",
+        required: true,
+        orderIndex: 0,
+        config: null,
+        options: [],
+      },
+    ]);
+
+    expect(() =>
+      validateAnswersAgainstSurvey(survey, { question_1: 123 as unknown as string }),
+    ).toThrow("文本题答案格式错误");
   });
 });


### PR DESCRIPTION
## Summary
- 新增下拉选择（dropdown）和日期选择（date）两种题型，支持编辑器创建和公开填写
- 新增问卷过期时间控制，支持编辑器设置、公开接口校验、过期提示页面
- 补齐单元测试和 E2E 测试覆盖

## Test Plan
- [ ] 管理员可在编辑器中创建含 dropdown 和 date 的问卷
- [ ] 公开填写页正常渲染并提交 dropdown 和 date 答案
- [ ] 过期问卷无法被公开访问和提交，显示"问卷已过期"
- [ ] 预览模式不受过期时间限制
- [ ] `pnpm test` 和 `pnpm test:e2e` 全部通过