### PR TITLE
chore(gitignore): 增加 *.db 忽略规则

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@
 .worktrees/
 data/*.sqlite
 data/*.sqlite-*
+*.db
 
 # debug
 npm-debug.log*


### PR DESCRIPTION
## 目的/结论
将本地 SQLite 数据库文件（如 `local.db`）加入 `.gitignore`，避免误提交。

## 背景
- 项目使用 better-sqlite3 / drizzle，本地开发会在仓库根目录生成 `local.db`。
- 现有 `.gitignore` 仅忽略 `data/*.sqlite`，不覆盖根目录 `*.db`。
- PR #9（feature/ui-optimization）的 UI 改动已被 master 上的 PR #7、#8 覆盖；从中拆出唯一仍有价值的 `.gitignore` 改动单独提交。

## 改动点
- `.gitignore`：在 `data/*.sqlite-*` 之后追加 `*.db`。

## 影响与风险
- 仅影响 git 跟踪规则，不改业务代码。
- 如果项目内已存在被跟踪的 `*.db` 文件，需要单独 `git rm --cached` 处理；本次扫描未发现已跟踪的 `*.db` 文件。

## 验收
- `git check-ignore local.db` 期望命中。
- 后续 PR #9 可关闭。

🤖 Generated with [Claude Code](https://claude.com/claude-code)