### PR TITLE
fix(share): show friendly notice instead of 404 for unpublished surveys

### DIFF
--- a/app/surveys/[id]/fill/page.tsx
+++ b/app/surveys/[id]/fill/page.tsx
@@ -30,7 +30,25 @@ export default async function SurveyFillPage({
   }
 
   if (survey.status !== "published" && preview !== "1") {
-    notFound();
+    if (survey.status === "draft") {
+      return (
+        <main className="mx-auto flex min-h-screen max-w-3xl flex-col items-center justify-center px-6 text-center">
+          <h1 className="text-2xl font-semibold">问卷暂未发布</h1>
+          <p className="mt-2 text-slate-600">
+            该问卷尚未发布，请联系问卷创建者发布后再访问。
+          </p>
+        </main>
+      );
+    }
+
+    return (
+      <main className="mx-auto flex min-h-screen max-w-3xl flex-col items-center justify-center px-6 text-center">
+        <h1 className="text-2xl font-semibold">问卷已关闭</h1>
+        <p className="mt-2 text-slate-600">
+          该问卷已关闭，不再接受新的填写。
+        </p>
+      </main>
+    );
   }
 
   if (survey.expiresAt && Math.floor(Date.now() / 1000) > survey.expiresAt && preview !== "1") {

--- a/components/survey-editor/editor-shell.tsx
+++ b/components/survey-editor/editor-shell.tsx
@@ -95,6 +95,10 @@ export function EditorShell({ survey }: { survey?: SurveyDetail | null }) {
       toast.error("请先保存问卷");
       return;
     }
+    if (survey.status !== "published") {
+      toast.error("问卷未发布，请先发布后再分享");
+      return;
+    }
     const url = `${window.location.origin}/surveys/${survey.id}/fill`;
     setShareUrl(url);
     setCopied(false);

--- a/tests/e2e/survey-publish-gating.spec.ts
+++ b/tests/e2e/survey-publish-gating.spec.ts
@@ -1,0 +1,125 @@
+import { expect, test } from "@playwright/test";
+
+async function getAdminCookie(
+  page: import("@playwright/test").Page,
+): Promise<string> {
+  await page.goto("/login");
+  await page
+    .getByLabel("用户名")
+    .fill(process.env.E2E_ADMIN_USERNAME ?? "admin");
+  await page
+    .getByLabel("密码")
+    .fill(process.env.E2E_ADMIN_PASSWORD ?? "secret123");
+  await page.getByRole("button", { name: "登录" }).click();
+  await expect(page).toHaveURL(/\/surveys$/);
+
+  const cookies = await page.context().cookies();
+  const sessionCookie = cookies.find(
+    (c) => c.name === "juanbing_admin_session",
+  );
+  expect(sessionCookie).toBeTruthy();
+  return `juanbing_admin_session=${sessionCookie!.value}`;
+}
+
+async function createSurvey(
+  page: import("@playwright/test").Page,
+  cookie: string,
+): Promise<number> {
+  const response = await page.request.post("/api/surveys", {
+    headers: { Cookie: cookie },
+    data: {
+      title: "草稿问卷",
+      questions: [
+        {
+          type: "text",
+          title: "姓名",
+          required: false,
+          orderIndex: 0,
+          config: null,
+          options: [],
+        },
+      ],
+    },
+  });
+  expect(response.ok()).toBeTruthy();
+  const { data } = await response.json();
+  return data.id as number;
+}
+
+test("draft survey fill page shows unpublished notice instead of 404", async ({
+  browser,
+  page,
+}) => {
+  const cookie = await getAdminCookie(page);
+  const surveyId = await createSurvey(page, cookie);
+
+  // Public visitor (no admin cookie) accesses share link of a draft survey.
+  const publicContext = await browser.newContext();
+  const publicPage = await publicContext.newPage();
+
+  const response = await publicPage.goto(`/surveys/${surveyId}/fill`);
+  expect(response?.status()).toBe(200);
+  await expect(publicPage.getByText("问卷暂未发布")).toBeVisible();
+  await expect(
+    publicPage.getByRole("button", { name: "提交问卷" }),
+  ).toHaveCount(0);
+
+  await publicContext.close();
+});
+
+test("closed survey fill page shows closed notice instead of 404", async ({
+  browser,
+  page,
+}) => {
+  const cookie = await getAdminCookie(page);
+  const surveyId = await createSurvey(page, cookie);
+
+  // Publish then close the survey.
+  await page.request.post(`/api/surveys/${surveyId}/publish`, {
+    headers: { Cookie: cookie },
+    data: { status: "published" },
+  });
+  await page.request.post(`/api/surveys/${surveyId}/publish`, {
+    headers: { Cookie: cookie },
+    data: { status: "closed" },
+  });
+
+  const publicContext = await browser.newContext();
+  const publicPage = await publicContext.newPage();
+
+  const response = await publicPage.goto(`/surveys/${surveyId}/fill`);
+  expect(response?.status()).toBe(200);
+  await expect(
+    publicPage.getByRole("heading", { name: "问卷已关闭" }),
+  ).toBeVisible();
+
+  await publicContext.close();
+});
+
+test("editor share button refuses to share an unpublished survey", async ({
+  page,
+}) => {
+  await page.goto("/login");
+  await page
+    .getByLabel("用户名")
+    .fill(process.env.E2E_ADMIN_USERNAME ?? "admin");
+  await page
+    .getByLabel("密码")
+    .fill(process.env.E2E_ADMIN_PASSWORD ?? "secret123");
+  await page.getByRole("button", { name: "登录" }).click();
+  await expect(page).toHaveURL(/\/surveys$/);
+
+  await page.getByRole("link", { name: "新建问卷" }).click();
+  await page.locator("input").first().fill("草稿不可分享");
+  await page.getByRole("button", { name: "填空题" }).click();
+  await page.getByRole("button", { name: "保存" }).click();
+  await expect(page.getByText("问卷已保存")).toBeVisible();
+  await expect(page).toHaveURL(/\/surveys\/\d+$/);
+
+  // Survey is in draft status by default.
+  await page.getByRole("button", { name: "分享" }).click();
+
+  await expect(page.getByText("问卷未发布，请先发布后再分享")).toBeVisible();
+  // Dialog must not open – there should be no "复制链接" button visible.
+  await expect(page.getByRole("button", { name: "复制链接" })).toHaveCount(0);
+});


### PR DESCRIPTION
## 目的 / 结论

修复 #5：访客通过分享链接打开**未发布**或**已关闭**的问卷时不再返回 404，而是看到对应的友好提示页；同时编辑器的"分享"按钮在问卷未发布时直接拒绝，避免源头泄露失效链接。

## 背景

- `app/surveys/[id]/fill/page.tsx` 之前对 `status !== "published"` 直接 `notFound()`，访客侧体验为 404，无法判断"未发布"还是"页面不存在"。
- `components/survey-editor/editor-shell.tsx` 的"分享"按钮未做状态门禁，任何阶段都能弹出复制链接对话框，导致草稿期生成的链接发出去就是 404。
- 现有的 `survey-list.tsx` 已经有"仅发布后可分享"的样例可以对齐。

## 方案 / 改动点

| 文件 | 改动 |
| --- | --- |
| `app/surveys/[id]/fill/page.tsx` | `draft` → "问卷暂未发布" 提示页；`closed` → "问卷已关闭" 提示页；预览模式 (`?preview=1`) 仍可命中以便管理员校验。 |
| `components/survey-editor/editor-shell.tsx` | `handleShare` 增加 `survey.status !== "published"` 校验，触发 `toast.error("问卷未发布，请先发布后再分享")`，对话框不再打开。 |
| `tests/e2e/survey-publish-gating.spec.ts` | 三个用例：草稿访客提示 / 已关闭访客提示 / 编辑器分享被拒。 |

## 影响与风险

- 仅影响公开访问层与编辑器交互层，未触碰 API、数据库或权限模型。
- 已发布问卷的填写路径与预览模式行为保持不变。
- 复用 "已过期" 提示页的视觉样式，无新增样式风险。

## 验证结果

- ✅ 新增 E2E：3 / 3 通过（先 RED 后 GREEN，符合 TDD）
- ✅ 全量 E2E：9 / 9 通过
- ✅ 单元测试：24 / 24 通过
- ✅ ESLint：通过
- ✅ `tsc --noEmit`：通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)