### PR TITLE
feat: evaluation template system

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,16 +13,16 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: '20'
           cache: 'pnpm'
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: 9
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -40,16 +40,16 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: '20'
           cache: 'pnpm'
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: 9
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ ENV ADMIN_PASSWORD_HASH="build-time-dummy-password-hash-long-enough"
 RUN corepack enable pnpm && pnpm build
 
 FROM base AS runner
+RUN apk add --no-cache libc6-compat
 WORKDIR /app
 ENV NODE_ENV=production
 ENV NEXT_TELEMETRY_DISABLED=1
@@ -30,6 +31,7 @@ COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
 COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
 COPY --from=builder --chown=nextjs:nodejs /app/public ./public
 COPY --from=builder --chown=nextjs:nodejs /app/drizzle ./drizzle
+COPY --from=deps --chown=nextjs:nodejs /app/node_modules ./node_modules
 USER nextjs
 EXPOSE 18080
 ENV PORT=18080

--- a/app/api/evaluation-templates/[id]/clone/route.ts
+++ b/app/api/evaluation-templates/[id]/clone/route.ts
@@ -1,0 +1,15 @@
+import { NextRequest } from "next/server";
+
+import { requireAdminSession } from "@/lib/auth/session";
+import { created, fromError } from "@/lib/http/responses";
+import { cloneEvaluationTemplate } from "@/lib/evaluations/template-service";
+
+export async function POST(_request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  try {
+    await requireAdminSession();
+    const { id } = await params;
+    return created(await cloneEvaluationTemplate(Number(id)));
+  } catch (error) {
+    return fromError(error);
+  }
+}

--- a/app/api/evaluation-templates/[id]/route.ts
+++ b/app/api/evaluation-templates/[id]/route.ts
@@ -1,0 +1,44 @@
+import { NextRequest } from "next/server";
+
+import { requireAdminSession } from "@/lib/auth/session";
+import { fromError, noContent, ok } from "@/lib/http/responses";
+import {
+  archiveEvaluationTemplate,
+  getEvaluationTemplateById,
+  updateEvaluationTemplate,
+} from "@/lib/evaluations/template-service";
+
+export async function GET(_request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  try {
+    await requireAdminSession();
+    const { id } = await params;
+    const template = await getEvaluationTemplateById(Number(id));
+    if (!template) {
+      return fromError({ status: 404, message: "模板不存在" });
+    }
+    return ok(template);
+  } catch (error) {
+    return fromError(error);
+  }
+}
+
+export async function PUT(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  try {
+    await requireAdminSession();
+    const { id } = await params;
+    return ok(await updateEvaluationTemplate(Number(id), await request.json()));
+  } catch (error) {
+    return fromError(error);
+  }
+}
+
+export async function DELETE(_request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  try {
+    await requireAdminSession();
+    const { id } = await params;
+    await archiveEvaluationTemplate(Number(id));
+    return noContent();
+  } catch (error) {
+    return fromError(error);
+  }
+}

--- a/app/api/evaluation-templates/route.ts
+++ b/app/api/evaluation-templates/route.ts
@@ -1,0 +1,31 @@
+import { NextRequest } from "next/server";
+
+import { requireAdminSession } from "@/lib/auth/session";
+import { created, fromError, ok } from "@/lib/http/responses";
+import {
+  createEvaluationTemplate,
+  listEvaluationTemplates,
+} from "@/lib/evaluations/template-service";
+import { evaluationTemplateQuerySchema } from "@/lib/evaluations/template-validators";
+
+export async function GET(request: NextRequest) {
+  try {
+    await requireAdminSession();
+    const searchParams = request.nextUrl.searchParams;
+    const parsed = evaluationTemplateQuerySchema.parse({
+      builtin: searchParams.get("builtin") ?? undefined,
+    });
+    return ok(await listEvaluationTemplates(parsed));
+  } catch (error) {
+    return fromError(error);
+  }
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    await requireAdminSession();
+    return created(await createEvaluationTemplate(await request.json()));
+  } catch (error) {
+    return fromError(error);
+  }
+}

--- a/app/evaluations/[id]/page.tsx
+++ b/app/evaluations/[id]/page.tsx
@@ -37,6 +37,11 @@ export default async function EvaluationDetailPage({
   return (
     <AdminShell title={cycle.title}>
       <div className="space-y-6">
+        {cycle.templateId && (
+          <div className="inline-flex items-center rounded-full bg-blue-50 px-3 py-1 text-xs font-medium text-blue-700">
+            基于模板创建
+          </div>
+        )}
         <ProgressOverview
           cycle={cycle}
           subjects={subjects}

--- a/app/evaluations/templates/[id]/edit/page.tsx
+++ b/app/evaluations/templates/[id]/edit/page.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { useParams, useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
+
+import { TemplateForm } from "@/components/evaluations/template-form";
+import type { EvaluationTemplate } from "@/lib/evaluations/template-types";
+
+export default function EditTemplatePage() {
+  const router = useRouter();
+  const params = useParams();
+  const id = Number(params.id);
+  const [template, setTemplate] = useState<EvaluationTemplate | null>(null);
+
+  useEffect(() => {
+    fetch(`/api/evaluation-templates/${id}`)
+      .then((res) => res.json())
+      .then((data) => setTemplate(data.data));
+  }, [id]);
+
+  const handleSubmit = async (data: {
+    name: string;
+    description: string | null;
+    surveyId: number;
+    anonymityThreshold: number;
+    relationshipRules: { type: string; count: number; required: boolean }[];
+    timeRule: { type: "relative"; durationDays: number };
+  }) => {
+    const res = await fetch(`/api/evaluation-templates/${id}`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(data),
+    });
+    if (res.ok) {
+      router.push("/evaluations/templates");
+    } else {
+      alert("更新失败");
+    }
+  };
+
+  if (!template) return <div>加载中...</div>;
+
+  return (
+    <div className="container mx-auto max-w-2xl py-8">
+      <h1 className="mb-6 text-2xl font-bold">编辑评价模板</h1>
+      <TemplateForm initial={template} onSubmit={handleSubmit} />
+    </div>
+  );
+}

--- a/app/evaluations/templates/new/page.tsx
+++ b/app/evaluations/templates/new/page.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+
+import { TemplateForm } from "@/components/evaluations/template-form";
+
+export default function NewTemplatePage() {
+  const router = useRouter();
+
+  const handleSubmit = async (data: Parameters<typeof TemplateForm>["onSubmit"] extends (d: infer T) => unknown ? T : never) => {
+    const res = await fetch("/api/evaluation-templates", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(data),
+    });
+    if (res.ok) {
+      router.push("/evaluations/templates");
+    } else {
+      alert("创建失败");
+    }
+  };
+
+  return (
+    <div className="container mx-auto max-w-2xl py-8">
+      <h1 className="mb-6 text-2xl font-bold">新建评价模板</h1>
+      <TemplateForm onSubmit={handleSubmit} />
+    </div>
+  );
+}

--- a/app/evaluations/templates/new/page.tsx
+++ b/app/evaluations/templates/new/page.tsx
@@ -3,11 +3,12 @@
 import { useRouter } from "next/navigation";
 
 import { TemplateForm } from "@/components/evaluations/template-form";
+import type { TemplateFormProps } from "@/components/evaluations/template-form";
 
 export default function NewTemplatePage() {
   const router = useRouter();
 
-  const handleSubmit = async (data: Parameters<typeof TemplateForm>["onSubmit"] extends (d: infer T) => unknown ? T : never) => {
+  const handleSubmit = async (data: Parameters<Required<TemplateFormProps>["onSubmit"]>[0]) => {
     const res = await fetch("/api/evaluation-templates", {
       method: "POST",
       headers: { "Content-Type": "application/json" },

--- a/app/evaluations/templates/page.tsx
+++ b/app/evaluations/templates/page.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
+import { Copy, Pencil, Trash } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import type { EvaluationTemplate } from "@/lib/evaluations/template-types";
+
+export default function TemplatesPage() {
+  const router = useRouter();
+  const [templates, setTemplates] = useState<EvaluationTemplate[]>([]);
+
+  useEffect(() => {
+    fetch("/api/evaluation-templates")
+      .then((res) => res.json())
+      .then((data) => setTemplates(data.data ?? []));
+  }, []);
+
+  const handleClone = async (id: number) => {
+    const res = await fetch(`/api/evaluation-templates/${id}/clone`, { method: "POST" });
+    if (res.ok) {
+      const { data } = await res.json();
+      setTemplates((prev) => [...prev, data]);
+    }
+  };
+
+  const handleArchive = async (id: number) => {
+    if (!confirm("确定归档此模板？")) return;
+    const res = await fetch(`/api/evaluation-templates/${id}`, { method: "DELETE" });
+    if (res.ok) {
+      setTemplates((prev) => prev.filter((t) => t.id !== id));
+    }
+  };
+
+  return (
+    <div className="container mx-auto py-8">
+      <div className="mb-6 flex items-center justify-between">
+        <h1 className="text-2xl font-bold">评价模板管理</h1>
+        <Button onClick={() => router.push("/evaluations/templates/new")}>新建模板</Button>
+      </div>
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>名称</TableHead>
+            <TableHead>类型</TableHead>
+            <TableHead>匿名阈值</TableHead>
+            <TableHead>持续天数</TableHead>
+            <TableHead className="text-right">操作</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {templates.map((t) => (
+            <TableRow key={t.id}>
+              <TableCell>{t.name}</TableCell>
+              <TableCell>{t.isBuiltin ? "系统" : "自定义"}</TableCell>
+              <TableCell>{t.anonymityThreshold}</TableCell>
+              <TableCell>{t.timeRule.durationDays}</TableCell>
+              <TableCell className="text-right">
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  onClick={() => handleClone(t.id)}
+                  title="克隆"
+                >
+                  <Copy className="h-4 w-4" />
+                </Button>
+                {!t.isBuiltin && (
+                  <>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      onClick={() => router.push(`/evaluations/templates/${t.id}/edit`)}
+                      title="编辑"
+                    >
+                      <Pencil className="h-4 w-4" />
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      onClick={() => handleArchive(t.id)}
+                      title="归档"
+                    >
+                      <Trash className="h-4 w-4" />
+                    </Button>
+                  </>
+                )}
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}

--- a/components/evaluations/anonymity-threshold-field.tsx
+++ b/components/evaluations/anonymity-threshold-field.tsx
@@ -1,0 +1,28 @@
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+
+interface AnonymityThresholdFieldProps {
+  value: number;
+  onChange: (value: number) => void;
+}
+
+export function AnonymityThresholdField({ value, onChange }: AnonymityThresholdFieldProps) {
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center gap-2">
+        <Label htmlFor="anonymity-threshold">匿名阈值</Label>
+      </div>
+      <p className="text-sm text-muted-foreground">
+        匿名阈值用于保护评价者身份。当某个关系组（同级/下属/其他）的实际回收份数低于此数值时，该组的评分和评语将自动隐藏。自评和直属经理评价不受此限制，始终展示。
+      </p>
+      <Input
+        id="anonymity-threshold"
+        type="number"
+        min={1}
+        max={20}
+        value={value}
+        onChange={(e) => onChange(Number(e.target.value))}
+      />
+    </div>
+  );
+}

--- a/components/evaluations/evaluation-form.tsx
+++ b/components/evaluations/evaluation-form.tsx
@@ -9,6 +9,18 @@ import { Card, CardContent } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { ArrowLeft } from "lucide-react";
+import { AnonymityThresholdField } from "./anonymity-threshold-field";
+import { TemplateSelector } from "./template-selector";
+import type { EvaluationTemplate } from "@/lib/evaluations/template-types";
+
+export function formatDateTimeLocal(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  const hours = String(date.getHours()).padStart(2, "0");
+  const minutes = String(date.getMinutes()).padStart(2, "0");
+  return `${year}-${month}-${day}T${hours}:${minutes}`;
+}
 
 export function EvaluationForm({
   surveys,
@@ -23,8 +35,9 @@ export function EvaluationForm({
     surveyId: "",
     startsAt: "",
     endsAt: "",
-    anonymityThreshold: "3",
+    anonymityThreshold: 3,
   });
+  const [selectedTemplate, setSelectedTemplate] = useState<EvaluationTemplate | null>(null);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -41,7 +54,8 @@ export function EvaluationForm({
         endsAt: form.endsAt
           ? Math.floor(new Date(form.endsAt).getTime() / 1000)
           : null,
-        anonymityThreshold: Number(form.anonymityThreshold),
+        anonymityThreshold: form.anonymityThreshold,
+        templateId: selectedTemplate?.id ?? null,
       };
 
       const response = await fetch("/api/evaluations", {
@@ -73,6 +87,31 @@ export function EvaluationForm({
       <Card>
         <CardContent className="p-6">
           <form className="space-y-4" onSubmit={handleSubmit}>
+            <div className="space-y-2">
+              <Label>使用模板</Label>
+              <TemplateSelector
+                value={selectedTemplate?.id}
+                onChange={(template) => {
+                  setSelectedTemplate(template);
+                  if (template) {
+                    setForm((f) => ({
+                      ...f,
+                      title: `${template.name}（${new Date().getFullYear()}）`,
+                      surveyId: String(template.surveyId),
+                      anonymityThreshold: template.anonymityThreshold,
+                    }));
+                    const today = new Date();
+                    const end = new Date(today);
+                    end.setDate(today.getDate() + template.timeRule.durationDays);
+                    setForm((f) => ({
+                      ...f,
+                      startsAt: formatDateTimeLocal(today),
+                      endsAt: formatDateTimeLocal(end),
+                    }));
+                  }
+                }}
+              />
+            </div>
             <div className="space-y-2">
               <Label htmlFor="title">项目名称 *</Label>
               <Input
@@ -137,25 +176,10 @@ export function EvaluationForm({
                 />
               </div>
             </div>
-            <div className="space-y-2">
-              <Label htmlFor="anonymityThreshold">匿名阈值</Label>
-              <Input
-                id="anonymityThreshold"
-                type="number"
-                min={2}
-                max={10}
-                value={form.anonymityThreshold}
-                onChange={(e) =>
-                  setForm((f) => ({
-                    ...f,
-                    anonymityThreshold: e.target.value,
-                  }))
-                }
-              />
-              <p className="text-xs text-slate-500">
-                peer、direct_report、other 关系组的评分和文本只有达到该人数才单独展示
-              </p>
-            </div>
+            <AnonymityThresholdField
+              value={form.anonymityThreshold}
+              onChange={(value) => setForm((f) => ({ ...f, anonymityThreshold: value }))}
+            />
             <div className="flex justify-end gap-2 pt-4">
               <Button
                 type="button"

--- a/components/evaluations/relationship-rule-builder.tsx
+++ b/components/evaluations/relationship-rule-builder.tsx
@@ -1,0 +1,66 @@
+import { Minus, Plus } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
+import type { RelationshipRule } from "@/lib/evaluations/template-types";
+
+const RELATIONSHIP_LABELS: Record<string, string> = {
+  self: "自评",
+  manager: "直属经理",
+  peer: "同级",
+  direct_report: "下属",
+  other: "其他",
+};
+
+interface RelationshipRuleBuilderProps {
+  rules: RelationshipRule[];
+  onChange: (rules: RelationshipRule[]) => void;
+}
+
+export function RelationshipRuleBuilder({ rules, onChange }: RelationshipRuleBuilderProps) {
+  const updateRule = (index: number, patch: Partial<RelationshipRule>) => {
+    const next = rules.map((r, i) => (i === index ? { ...r, ...patch } : r));
+    onChange(next);
+  };
+
+  return (
+    <div className="space-y-4">
+      <Label>评价关系规则</Label>
+      {rules.map((rule, index) => (
+        <div key={rule.type} className="flex items-center gap-4 rounded border p-3">
+          <span className="w-20 font-medium">{RELATIONSHIP_LABELS[rule.type]}</span>
+          <div className="flex items-center gap-2">
+            <Button
+              variant="outline"
+              size="icon"
+              type="button"
+              onClick={() => updateRule(index, { count: Math.max(0, rule.count - 1) })}
+            >
+              <Minus className="h-4 w-4" />
+            </Button>
+            <span className="w-8 text-center">{rule.count}</span>
+            <Button
+              variant="outline"
+              size="icon"
+              type="button"
+              onClick={() => updateRule(index, { count: Math.min(50, rule.count + 1) })}
+            >
+              <Plus className="h-4 w-4" />
+            </Button>
+          </div>
+          <div className="flex items-center gap-2">
+            <Switch
+              id={`required-${rule.type}`}
+              checked={rule.required}
+              onCheckedChange={(checked) => updateRule(index, { required: !!checked })}
+            />
+            <Label htmlFor={`required-${rule.type}`} className="text-sm font-normal">
+              必填
+            </Label>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/components/evaluations/template-form.tsx
+++ b/components/evaluations/template-form.tsx
@@ -15,7 +15,7 @@ const DEFAULT_RULES: RelationshipRule[] = [
   { type: "direct_report", count: 3, required: false },
 ];
 
-interface TemplateFormProps {
+export interface TemplateFormProps {
   initial?: EvaluationTemplate | null;
   onSubmit: (data: {
     name: string;

--- a/components/evaluations/template-form.tsx
+++ b/components/evaluations/template-form.tsx
@@ -1,0 +1,98 @@
+import { useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { AnonymityThresholdField } from "./anonymity-threshold-field";
+import { RelationshipRuleBuilder } from "./relationship-rule-builder";
+import type { EvaluationTemplate, RelationshipRule, TimeRule } from "@/lib/evaluations/template-types";
+
+const DEFAULT_RULES: RelationshipRule[] = [
+  { type: "self", count: 1, required: true },
+  { type: "manager", count: 1, required: true },
+  { type: "peer", count: 2, required: false },
+  { type: "direct_report", count: 3, required: false },
+];
+
+interface TemplateFormProps {
+  initial?: EvaluationTemplate | null;
+  onSubmit: (data: {
+    name: string;
+    description: string | null;
+    surveyId: number;
+    anonymityThreshold: number;
+    relationshipRules: RelationshipRule[];
+    timeRule: TimeRule;
+  }) => void;
+  loading?: boolean;
+}
+
+export function TemplateForm({ initial, onSubmit, loading }: TemplateFormProps) {
+  const [name, setName] = useState(initial?.name ?? "");
+  const [description, setDescription] = useState(initial?.description ?? "");
+  const [surveyId, setSurveyId] = useState(initial?.surveyId ?? 0);
+  const [anonymityThreshold, setAnonymityThreshold] = useState(
+    initial?.anonymityThreshold ?? 3
+  );
+  const [relationshipRules, setRelationshipRules] = useState<RelationshipRule[]>(
+    initial?.relationshipRules ?? DEFAULT_RULES
+  );
+  const [durationDays, setDurationDays] = useState(
+    initial?.timeRule?.durationDays ?? 14
+  );
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    onSubmit({
+      name,
+      description: description || null,
+      surveyId,
+      anonymityThreshold,
+      relationshipRules,
+      timeRule: { type: "relative", durationDays },
+    });
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-6">
+      <div className="space-y-2">
+        <Label htmlFor="name">模板名称</Label>
+        <Input id="name" value={name} onChange={(e) => setName(e.target.value)} required />
+      </div>
+      <div className="space-y-2">
+        <Label htmlFor="description">说明</Label>
+        <Textarea
+          id="description"
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+        />
+      </div>
+      <div className="space-y-2">
+        <Label htmlFor="survey-id">绑定问卷 ID</Label>
+        <Input
+          id="survey-id"
+          type="number"
+          value={surveyId || ""}
+          onChange={(e) => setSurveyId(Number(e.target.value))}
+          required
+        />
+      </div>
+      <AnonymityThresholdField value={anonymityThreshold} onChange={setAnonymityThreshold} />
+      <RelationshipRuleBuilder rules={relationshipRules} onChange={setRelationshipRules} />
+      <div className="space-y-2">
+        <Label htmlFor="duration">默认持续天数</Label>
+        <Input
+          id="duration"
+          type="number"
+          min={1}
+          value={durationDays}
+          onChange={(e) => setDurationDays(Number(e.target.value))}
+        />
+      </div>
+      <Button type="submit" disabled={loading}>
+        {loading ? "保存中..." : initial ? "更新模板" : "创建模板"}
+      </Button>
+    </form>
+  );
+}

--- a/components/evaluations/template-selector.tsx
+++ b/components/evaluations/template-selector.tsx
@@ -25,7 +25,11 @@ export function TemplateSelector({ value, onChange }: TemplateSelectorProps) {
       .then((data) => setTemplates(data.data ?? []));
   }, []);
 
-  const handleChange = (id: string) => {
+  const handleChange = (id: string | null) => {
+    if (!id) {
+      onChange(null);
+      return;
+    }
     const template = templates.find((t) => t.id === Number(id));
     onChange(template ?? null);
   };

--- a/components/evaluations/template-selector.tsx
+++ b/components/evaluations/template-selector.tsx
@@ -1,0 +1,65 @@
+import { useEffect, useState } from "react";
+
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import type { EvaluationTemplate } from "@/lib/evaluations/template-types";
+
+interface TemplateSelectorProps {
+  value?: number;
+  onChange: (template: EvaluationTemplate | null) => void;
+}
+
+export function TemplateSelector({ value, onChange }: TemplateSelectorProps) {
+  const [templates, setTemplates] = useState<EvaluationTemplate[]>([]);
+
+  useEffect(() => {
+    fetch("/api/evaluation-templates")
+      .then((res) => res.json())
+      .then((data) => setTemplates(data.data ?? []));
+  }, []);
+
+  const handleChange = (id: string) => {
+    const template = templates.find((t) => t.id === Number(id));
+    onChange(template ?? null);
+  };
+
+  const builtin = templates.filter((t) => t.isBuiltin);
+  const custom = templates.filter((t) => !t.isBuiltin);
+
+  return (
+    <Select value={value?.toString()} onValueChange={handleChange}>
+      <SelectTrigger className="w-full">
+        <SelectValue placeholder="选择模板（可选）" />
+      </SelectTrigger>
+      <SelectContent>
+        {builtin.length > 0 && (
+          <SelectGroup>
+            <SelectLabel>系统模板</SelectLabel>
+            {builtin.map((t) => (
+              <SelectItem key={t.id} value={t.id.toString()}>
+                {t.name}
+              </SelectItem>
+            ))}
+          </SelectGroup>
+        )}
+        {custom.length > 0 && (
+          <SelectGroup>
+            <SelectLabel>我的模板</SelectLabel>
+            {custom.map((t) => (
+              <SelectItem key={t.id} value={t.id.toString()}>
+                {t.name}
+              </SelectItem>
+            ))}
+          </SelectGroup>
+        )}
+      </SelectContent>
+    </Select>
+  );
+}

--- a/docs/superpowers/plans/2026-04-27-evaluation-template-implementation.md
+++ b/docs/superpowers/plans/2026-04-27-evaluation-template-implementation.md
@@ -1,0 +1,1757 @@
+# 360 环评模板系统 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 实现 360 环评模板系统，支持系统内置模板和管理员自定义模板，创建评价周期时可选择模板自动回填配置。
+
+**Architecture:** 在现有 360 环评模块旁新增模板子模块（`template-*.ts`），遵循现有 repository-service-route 分层。模板数据独立存储，`evaluation_cycles` 通过 `template_id` 溯源。前端在创建周期页面增加模板选择器，新增模板管理页面。
+
+**Tech Stack:** Next.js App Router, Drizzle ORM (SQLite), Zod, Vitest, Playwright
+
+---
+
+## 文件结构映射
+
+### 数据库层
+- `lib/db/schema.ts` — 新增 `evaluationTemplates` 表，为 `evaluationCycles` 添加 `templateId` 字段
+- `drizzle/0003_evaluation_templates.sql` — 自动生成的 migration
+
+### 模板服务层（新建）
+- `lib/evaluations/template-types.ts` — 模板相关 TypeScript 类型
+- `lib/evaluations/template-validators.ts` — Zod 校验 schema
+- `lib/evaluations/template-repository.ts` — Drizzle ORM 数据库操作
+- `lib/evaluations/template-service.ts` — 业务逻辑（CRUD、克隆、归档）
+
+### 现有服务层改动
+- `lib/evaluations/types.ts` — `EvaluationCycleInput` 新增 `templateId` 可选字段
+- `lib/evaluations/validators.ts` — `evaluationCycleInputSchema` 新增 `templateId`
+- `lib/evaluations/service.ts` — `createEvaluationCycle` 支持从模板预填字段
+- `lib/evaluations/repository.ts` — `insertEvaluationCycle` 接收 `templateId`
+
+### API 层（新建）
+- `app/api/evaluation-templates/route.ts` — GET 列表 / POST 创建
+- `app/api/evaluation-templates/[id]/route.ts` — GET 详情 / PUT 编辑 / DELETE 归档
+- `app/api/evaluation-templates/[id]/clone/route.ts` — POST 克隆
+
+### 页面与组件（新建）
+- `app/evaluations/templates/page.tsx` — 模板列表页
+- `app/evaluations/templates/new/page.tsx` — 新建模板页
+- `app/evaluations/templates/[id]/edit/page.tsx` — 编辑模板页
+- `components/evaluations/template-selector.tsx` — 模板下拉选择器
+- `components/evaluations/template-form.tsx` — 模板编辑表单
+- `components/evaluations/relationship-rule-builder.tsx` — 关系规则配置器
+- `components/evaluations/anonymity-threshold-field.tsx` — 匿名阈值输入+说明
+
+### 现有页面改动
+- `app/evaluations/new/page.tsx` — 顶部添加 TemplateSelector，选模板后回填表单
+- `app/evaluations/[id]/page.tsx` — 如有 templateId，显示溯源标签
+
+### 测试（新建）
+- `tests/lib/evaluations/template-service.test.ts` — 模板 service 单元测试
+- `tests/e2e/evaluation-template.spec.ts` — 模板管理 E2E 测试
+
+---
+
+## Task 1: Database Schema & Migration
+
+**Files:**
+- Modify: `lib/db/schema.ts`
+- Create: `drizzle/0003_evaluation_templates.sql` (via drizzle-kit generate)
+
+- [ ] **Step 1: Add `evaluationTemplates` table and `templateId` to `evaluationCycles`**
+
+修改 `lib/db/schema.ts`，在 `evaluationAssignments` 定义之后添加：
+
+```typescript
+export const evaluationTemplates = sqliteTable("evaluation_templates", {
+  id: integer("id").primaryKey({ autoIncrement: true }),
+  name: text("name").notNull(),
+  description: text("description"),
+  surveyId: integer("survey_id")
+    .notNull()
+    .references(() => surveys.id, { onDelete: "restrict" }),
+  anonymityThreshold: integer("anonymity_threshold").notNull().default(3),
+  relationshipRules: text("relationship_rules").notNull(),
+  timeRule: text("time_rule").notNull(),
+  isBuiltin: integer("is_builtin", { mode: "boolean" }).notNull().default(false),
+  createdBy: integer("created_by").references(() => employees.id, {
+    onDelete: "set null",
+  }),
+  status: text("status", { enum: ["active", "archived"] })
+    .notNull()
+    .default("active"),
+  createdAt: integer("created_at").notNull().default(sql`(unixepoch())`),
+  updatedAt: integer("updated_at").notNull().default(sql`(unixepoch())`),
+});
+```
+
+然后修改 `evaluationCycles` 表，在 `anonymityThreshold` 之后添加：
+
+```typescript
+templateId: integer("template_id").references(() => evaluationTemplates.id, {
+  onDelete: "set null",
+}),
+```
+
+- [ ] **Step 2: Generate migration**
+
+Run:
+```bash
+npx drizzle-kit generate --name=evaluation_templates
+```
+
+Expected: 生成 `drizzle/0003_evaluation_templates.sql` 和更新 `drizzle/meta/`。
+
+- [ ] **Step 3: Apply migration**
+
+Run:
+```bash
+npx drizzle-kit migrate
+```
+
+Expected: 成功应用 migration，数据库新增 `evaluation_templates` 表和 `evaluation_cycles.template_id` 字段。
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add lib/db/schema.ts drizzle/
+git commit -m "feat(schema): add evaluation_templates table and template_id to cycles
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Template Types & Validators
+
+**Files:**
+- Create: `lib/evaluations/template-types.ts`
+- Create: `lib/evaluations/template-validators.ts`
+
+- [ ] **Step 1: Write template types**
+
+创建 `lib/evaluations/template-types.ts`：
+
+```typescript
+import type { EvaluationRelationship } from "./types";
+
+export type TemplateStatus = "active" | "archived";
+
+export type RelationshipRule = {
+  type: EvaluationRelationship;
+  count: number;
+  required: boolean;
+};
+
+export type TimeRule = {
+  type: "relative";
+  durationDays: number;
+};
+
+export type EvaluationTemplateInput = {
+  name: string;
+  description?: string | null;
+  surveyId: number;
+  anonymityThreshold: number;
+  relationshipRules: RelationshipRule[];
+  timeRule: TimeRule;
+};
+
+export type EvaluationTemplate = {
+  id: number;
+  name: string;
+  description: string | null;
+  surveyId: number;
+  anonymityThreshold: number;
+  relationshipRules: RelationshipRule[];
+  timeRule: TimeRule;
+  isBuiltin: boolean;
+  createdBy: number | null;
+  status: TemplateStatus;
+  createdAt: number;
+  updatedAt: number;
+};
+```
+
+- [ ] **Step 2: Write template validators**
+
+创建 `lib/evaluations/template-validators.ts`：
+
+```typescript
+import { z } from "zod";
+
+const relationshipRuleSchema = z.object({
+  type: z.enum(["self", "manager", "peer", "direct_report", "other"]),
+  count: z.number().int().min(0).max(50),
+  required: z.boolean(),
+});
+
+const timeRuleSchema = z.object({
+  type: z.literal("relative"),
+  durationDays: z.number().int().min(1).max(365),
+});
+
+export const evaluationTemplateInputSchema = z.object({
+  name: z.string().trim().min(1, "模板名称不能为空"),
+  description: z.string().trim().optional().nullable(),
+  surveyId: z.number().int().positive(),
+  anonymityThreshold: z.number().int().min(1).max(20),
+  relationshipRules: z.array(relationshipRuleSchema).min(1, "至少需要一条关系规则"),
+  timeRule: timeRuleSchema,
+});
+
+export const evaluationTemplateQuerySchema = z.object({
+  builtin: z
+    .enum(["true", "false"])
+    .optional()
+    .transform((v) => (v === undefined ? undefined : v === "true")),
+});
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add lib/evaluations/template-types.ts lib/evaluations/template-validators.ts
+git commit -m "feat(evaluations): add template types and validators
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Template Repository
+
+**Files:**
+- Create: `lib/evaluations/template-repository.ts`
+- Test: `tests/lib/evaluations/template-repository.test.ts`
+
+- [ ] **Step 1: Write failing repository tests**
+
+创建 `tests/lib/evaluations/template-repository.test.ts`：
+
+```typescript
+import { beforeEach, describe, expect, it } from "vitest";
+
+import {
+  archiveEvaluationTemplate,
+  findEvaluationTemplateById,
+  insertEvaluationTemplate,
+  listEvaluationTemplates,
+  updateEvaluationTemplate,
+} from "@/lib/evaluations/template-repository";
+import { resetDatabase } from "@/tests/helpers/reset-db";
+
+describe("template repository", () => {
+  beforeEach(() => {
+    resetDatabase();
+  });
+
+  it("should insert and find a template", async () => {
+    const id = await insertEvaluationTemplate({
+      name: "季度 360",
+      description: "季度员工评价",
+      surveyId: 1,
+      anonymityThreshold: 3,
+      relationshipRules: JSON.stringify([{ type: "self", count: 1, required: true }]),
+      timeRule: JSON.stringify({ type: "relative", durationDays: 14 }),
+      isBuiltin: false,
+      createdBy: null,
+    });
+
+    const found = await findEvaluationTemplateById(id);
+    expect(found).not.toBeNull();
+    expect(found!.name).toBe("季度 360");
+  });
+
+  it("should list active templates", async () => {
+    await insertEvaluationTemplate({
+      name: "T1",
+      description: null,
+      surveyId: 1,
+      anonymityThreshold: 3,
+      relationshipRules: "[]",
+      timeRule: JSON.stringify({ type: "relative", durationDays: 14 }),
+      isBuiltin: true,
+      createdBy: null,
+    });
+
+    const list = await listEvaluationTemplates();
+    expect(list).toHaveLength(1);
+  });
+
+  it("should archive a template", async () => {
+    const id = await insertEvaluationTemplate({
+      name: "T1",
+      description: null,
+      surveyId: 1,
+      anonymityThreshold: 3,
+      relationshipRules: "[]",
+      timeRule: JSON.stringify({ type: "relative", durationDays: 14 }),
+      isBuiltin: false,
+      createdBy: null,
+    });
+
+    await archiveEvaluationTemplate(id);
+    const found = await findEvaluationTemplateById(id);
+    expect(found!.status).toBe("archived");
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+```bash
+npx vitest run tests/lib/evaluations/template-repository.test.ts
+```
+
+Expected: FAIL with "Cannot find module '@/lib/evaluations/template-repository'".
+
+- [ ] **Step 3: Implement template repository**
+
+创建 `lib/evaluations/template-repository.ts`：
+
+```typescript
+import { and, eq } from "drizzle-orm";
+
+import { db } from "@/lib/db/client";
+import { evaluationTemplates } from "@/lib/db/schema";
+
+export async function insertEvaluationTemplate(data: {
+  name: string;
+  description: string | null;
+  surveyId: number;
+  anonymityThreshold: number;
+  relationshipRules: string;
+  timeRule: string;
+  isBuiltin: boolean;
+  createdBy: number | null;
+}): Promise<number> {
+  const now = Math.floor(Date.now() / 1000);
+  const result = db
+    .insert(evaluationTemplates)
+    .values({
+      name: data.name,
+      description: data.description,
+      surveyId: data.surveyId,
+      anonymityThreshold: data.anonymityThreshold,
+      relationshipRules: data.relationshipRules,
+      timeRule: data.timeRule,
+      isBuiltin: data.isBuiltin,
+      createdBy: data.createdBy,
+      status: "active",
+      createdAt: now,
+      updatedAt: now,
+    })
+    .run();
+
+  return Number(result.lastInsertRowid);
+}
+
+export async function findEvaluationTemplateById(id: number) {
+  return db
+    .select()
+    .from(evaluationTemplates)
+    .where(eq(evaluationTemplates.id, id))
+    .get();
+}
+
+export async function listEvaluationTemplates(filters?: { builtin?: boolean }) {
+  const conditions = [eq(evaluationTemplates.status, "active")];
+  if (filters?.builtin !== undefined) {
+    conditions.push(eq(evaluationTemplates.isBuiltin, filters.builtin));
+  }
+
+  return db
+    .select()
+    .from(evaluationTemplates)
+    .where(and(...conditions))
+    .orderBy(evaluationTemplates.isBuiltin, evaluationTemplates.updatedAt)
+    .all();
+}
+
+export async function updateEvaluationTemplate(
+  id: number,
+  data: {
+    name: string;
+    description: string | null;
+    surveyId: number;
+    anonymityThreshold: number;
+    relationshipRules: string;
+    timeRule: string;
+  }
+) {
+  const now = Math.floor(Date.now() / 1000);
+  db.update(evaluationTemplates)
+    .set({
+      name: data.name,
+      description: data.description,
+      surveyId: data.surveyId,
+      anonymityThreshold: data.anonymityThreshold,
+      relationshipRules: data.relationshipRules,
+      timeRule: data.timeRule,
+      updatedAt: now,
+    })
+    .where(eq(evaluationTemplates.id, id))
+    .run();
+}
+
+export async function archiveEvaluationTemplate(id: number) {
+  const now = Math.floor(Date.now() / 1000);
+  db.update(evaluationTemplates)
+    .set({ status: "archived", updatedAt: now })
+    .where(eq(evaluationTemplates.id, id))
+    .run();
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run:
+```bash
+npx vitest run tests/lib/evaluations/template-repository.test.ts
+```
+
+Expected: PASS (3 tests)。注意：数据库中需要有 surveys 表的数据，测试可能会因为 foreign key 约束失败。如果失败，需要在 reset-db 中确保基础表结构存在，或者调整测试数据。
+
+> 如果测试因外键约束失败，调整 `insertEvaluationTemplate` 调用中的 `surveyId` 为已存在的 survey ID，或在测试 helper 中预先创建 survey。
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/evaluations/template-repository.ts tests/lib/evaluations/template-repository.test.ts
+git commit -m "feat(evaluations): add template repository with tests
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Template Service
+
+**Files:**
+- Create: `lib/evaluations/template-service.ts`
+- Test: `tests/lib/evaluations/template-service.test.ts`
+
+- [ ] **Step 1: Write failing service tests**
+
+创建 `tests/lib/evaluations/template-service.test.ts`：
+
+```typescript
+import { beforeEach, describe, expect, it } from "vitest";
+
+import {
+  archiveEvaluationTemplate,
+  cloneEvaluationTemplate,
+  createEvaluationTemplate,
+  getEvaluationTemplateById,
+  listEvaluationTemplates,
+  updateEvaluationTemplate,
+} from "@/lib/evaluations/template-service";
+import { createSurvey } from "@/lib/surveys/service";
+import { resetDatabase } from "@/tests/helpers/reset-db";
+
+async function makeSurvey() {
+  return createSurvey({
+    title: "360 评价表",
+    questions: [
+      {
+        type: "rating",
+        title: "沟通协作",
+        required: true,
+        orderIndex: 0,
+        config: { maxRating: 5 },
+        options: [],
+      },
+    ],
+  });
+}
+
+describe("template service", () => {
+  beforeEach(() => {
+    resetDatabase();
+  });
+
+  it("should create a template", async () => {
+    const survey = await makeSurvey();
+    const template = await createEvaluationTemplate({
+      name: "季度 360",
+      surveyId: survey.id,
+      anonymityThreshold: 3,
+      relationshipRules: [{ type: "self", count: 1, required: true }],
+      timeRule: { type: "relative", durationDays: 14 },
+    });
+
+    expect(template.name).toBe("季度 360");
+    expect(template.relationshipRules).toEqual([{ type: "self", count: 1, required: true }]);
+  });
+
+  it("should clone a template", async () => {
+    const survey = await makeSurvey();
+    const original = await createEvaluationTemplate({
+      name: "季度 360",
+      surveyId: survey.id,
+      anonymityThreshold: 3,
+      relationshipRules: [{ type: "self", count: 1, required: true }],
+      timeRule: { type: "relative", durationDays: 14 },
+    });
+
+    const clone = await cloneEvaluationTemplate(original.id);
+    expect(clone.name).toBe("季度 360 副本");
+    expect(clone.surveyId).toBe(original.surveyId);
+    expect(clone.isBuiltin).toBe(false);
+  });
+
+  it("should reject updating a builtin template", async () => {
+    const survey = await makeSurvey();
+    const template = await createEvaluationTemplate({
+      name: "系统模板",
+      surveyId: survey.id,
+      anonymityThreshold: 3,
+      relationshipRules: [{ type: "self", count: 1, required: true }],
+      timeRule: { type: "relative", durationDays: 14 },
+      isBuiltin: true,
+    });
+
+    await expect(
+      updateEvaluationTemplate(template.id, {
+        name: "改名",
+        surveyId: survey.id,
+        anonymityThreshold: 3,
+        relationshipRules: [{ type: "self", count: 1, required: true }],
+        timeRule: { type: "relative", durationDays: 14 },
+      })
+    ).rejects.toThrow("系统内置模板不能编辑");
+  });
+
+  it("should archive a custom template", async () => {
+    const survey = await makeSurvey();
+    const template = await createEvaluationTemplate({
+      name: "季度 360",
+      surveyId: survey.id,
+      anonymityThreshold: 3,
+      relationshipRules: [{ type: "self", count: 1, required: true }],
+      timeRule: { type: "relative", durationDays: 14 },
+    });
+
+    await archiveEvaluationTemplate(template.id);
+    const found = await getEvaluationTemplateById(template.id);
+    expect(found!.status).toBe("archived");
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+```bash
+npx vitest run tests/lib/evaluations/template-service.test.ts
+```
+
+Expected: FAIL，找不到 template-service 模块。
+
+- [ ] **Step 3: Implement template service**
+
+创建 `lib/evaluations/template-service.ts`：
+
+```typescript
+import { ApiError } from "@/lib/http/api-error";
+import { getSurveyById } from "@/lib/surveys/service";
+import {
+  archiveEvaluationTemplate as archiveTemplateRepo,
+  findEvaluationTemplateById,
+  insertEvaluationTemplate,
+  listEvaluationTemplates as listTemplatesRepo,
+  updateEvaluationTemplate as updateTemplateRepo,
+} from "./template-repository";
+import type {
+  EvaluationTemplate,
+  EvaluationTemplateInput,
+  RelationshipRule,
+  TimeRule,
+} from "./template-types";
+import { evaluationTemplateInputSchema } from "./template-validators";
+
+function parseTemplateRow(row: {
+  relationshipRules: string;
+  timeRule: string;
+  [key: string]: unknown;
+}): Omit<typeof row, "relationshipRules" | "timeRule"> & {
+  relationshipRules: RelationshipRule[];
+  timeRule: TimeRule;
+} {
+  const { relationshipRules, timeRule, ...rest } = row;
+  return {
+    ...rest,
+    relationshipRules: JSON.parse(relationshipRules) as RelationshipRule[],
+    timeRule: JSON.parse(timeRule) as TimeRule,
+  };
+}
+
+export async function createEvaluationTemplate(
+  input: EvaluationTemplateInput & { isBuiltin?: boolean; createdBy?: number | null }
+): Promise<EvaluationTemplate> {
+  const parsed = evaluationTemplateInputSchema.parse(input);
+  const survey = await getSurveyById(parsed.surveyId);
+  if (!survey) {
+    throw new ApiError(404, "问卷不存在");
+  }
+
+  const id = await insertEvaluationTemplate({
+    name: parsed.name,
+    description: parsed.description ?? null,
+    surveyId: parsed.surveyId,
+    anonymityThreshold: parsed.anonymityThreshold,
+    relationshipRules: JSON.stringify(parsed.relationshipRules),
+    timeRule: JSON.stringify(parsed.timeRule),
+    isBuiltin: input.isBuiltin ?? false,
+    createdBy: input.createdBy ?? null,
+  });
+
+  const row = await findEvaluationTemplateById(id);
+  return parseTemplateRow(row!) as EvaluationTemplate;
+}
+
+export async function getEvaluationTemplateById(id: number): Promise<EvaluationTemplate | null> {
+  const row = await findEvaluationTemplateById(id);
+  if (!row) return null;
+  return parseTemplateRow(row) as EvaluationTemplate;
+}
+
+export async function listEvaluationTemplates(filters?: { builtin?: boolean }): Promise<EvaluationTemplate[]> {
+  const rows = await listTemplatesRepo(filters);
+  return rows.map((row) => parseTemplateRow(row) as EvaluationTemplate);
+}
+
+export async function updateEvaluationTemplate(
+  id: number,
+  input: EvaluationTemplateInput
+): Promise<EvaluationTemplate> {
+  const existing = await findEvaluationTemplateById(id);
+  if (!existing) {
+    throw new ApiError(404, "模板不存在");
+  }
+  if (existing.isBuiltin) {
+    throw new ApiError(403, "系统内置模板不能编辑");
+  }
+
+  const parsed = evaluationTemplateInputSchema.parse(input);
+  const survey = await getSurveyById(parsed.surveyId);
+  if (!survey) {
+    throw new ApiError(404, "问卷不存在");
+  }
+
+  await updateTemplateRepo(id, {
+    name: parsed.name,
+    description: parsed.description ?? null,
+    surveyId: parsed.surveyId,
+    anonymityThreshold: parsed.anonymityThreshold,
+    relationshipRules: JSON.stringify(parsed.relationshipRules),
+    timeRule: JSON.stringify(parsed.timeRule),
+  });
+
+  const row = await findEvaluationTemplateById(id);
+  return parseTemplateRow(row!) as EvaluationTemplate;
+}
+
+export async function archiveEvaluationTemplate(id: number): Promise<void> {
+  const existing = await findEvaluationTemplateById(id);
+  if (!existing) {
+    throw new ApiError(404, "模板不存在");
+  }
+  if (existing.isBuiltin) {
+    throw new ApiError(403, "系统内置模板不能归档");
+  }
+  await archiveTemplateRepo(id);
+}
+
+export async function cloneEvaluationTemplate(id: number): Promise<EvaluationTemplate> {
+  const existing = await getEvaluationTemplateById(id);
+  if (!existing) {
+    throw new ApiError(404, "模板不存在");
+  }
+
+  return createEvaluationTemplate({
+    name: `${existing.name} 副本`,
+    description: existing.description,
+    surveyId: existing.surveyId,
+    anonymityThreshold: existing.anonymityThreshold,
+    relationshipRules: existing.relationshipRules,
+    timeRule: existing.timeRule,
+  });
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run:
+```bash
+npx vitest run tests/lib/evaluations/template-service.test.ts
+```
+
+Expected: PASS (4 tests)。
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/evaluations/template-service.ts tests/lib/evaluations/template-service.test.ts
+git commit -m "feat(evaluations): add template service with CRUD, clone, archive
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: Modify Cycle Creation to Support Template
+
+**Files:**
+- Modify: `lib/evaluations/types.ts`
+- Modify: `lib/evaluations/validators.ts`
+- Modify: `lib/evaluations/repository.ts`
+- Modify: `lib/evaluations/service.ts`
+- Test: `tests/lib/evaluations/service.test.ts` (追加测试)
+
+- [ ] **Step 1: Write failing test for template-based cycle creation**
+
+在 `tests/lib/evaluations/service.test.ts` 中追加测试：
+
+```typescript
+import { createEvaluationTemplate } from "@/lib/evaluations/template-service";
+
+describe("create cycle from template", () => {
+  beforeEach(() => {
+    resetDatabase();
+  });
+
+  it("should create cycle pre-filled from template", async () => {
+    const survey = await createSurvey({
+      title: "360 评价表",
+      questions: [
+        {
+          type: "rating",
+          title: "沟通协作",
+          required: true,
+          orderIndex: 0,
+          config: { maxRating: 5 },
+          options: [],
+        },
+      ],
+    });
+
+    const template = await createEvaluationTemplate({
+      name: "季度 360",
+      surveyId: survey.id,
+      anonymityThreshold: 5,
+      relationshipRules: [{ type: "self", count: 1, required: true }],
+      timeRule: { type: "relative", durationDays: 14 },
+    });
+
+    const cycle = await createEvaluationCycle({
+      title: "2026 Q2",
+      surveyId: survey.id,
+      templateId: template.id,
+    });
+
+    expect(cycle.templateId).toBe(template.id);
+    expect(cycle.anonymityThreshold).toBe(5);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify it fails**
+
+Run:
+```bash
+npx vitest run tests/lib/evaluations/service.test.ts -t "create cycle from template"
+```
+
+Expected: FAIL，因为 `templateId` 字段不存在于 `EvaluationCycleInput`。
+
+- [ ] **Step 3: Update types, validators, repository, service**
+
+修改 `lib/evaluations/types.ts`，在 `EvaluationCycleInput` 中新增：
+
+```typescript
+export type EvaluationCycleInput = {
+  title: string;
+  description?: string | null;
+  surveyId: number;
+  startsAt?: number | null;
+  endsAt?: number | null;
+  anonymityThreshold?: number;
+  templateId?: number | null;
+};
+```
+
+修改 `lib/evaluations/validators.ts`，在 `evaluationCycleInputSchema` 中新增：
+
+```typescript
+export const evaluationCycleInputSchema = z.object({
+  title: z.string().trim().min(1, "项目名称不能为空"),
+  description: z.string().trim().optional().nullable(),
+  surveyId: z.number().int().positive(),
+  startsAt: z.number().int().nullable().optional(),
+  endsAt: z.number().int().nullable().optional(),
+  anonymityThreshold: z.number().int().min(1).max(20).optional(),
+  templateId: z.number().int().positive().nullable().optional(),
+});
+```
+
+修改 `lib/evaluations/repository.ts` 中的 `insertEvaluationCycle`：
+
+```typescript
+export async function insertEvaluationCycle(
+  input: EvaluationCycleInput,
+): Promise<number> {
+  const now = Math.floor(Date.now() / 1000);
+
+  const result = db
+    .insert(evaluationCycles)
+    .values({
+      title: input.title,
+      description: input.description ?? null,
+      status: "draft",
+      surveyId: input.surveyId,
+      startsAt: input.startsAt ?? null,
+      endsAt: input.endsAt ?? null,
+      anonymityThreshold: input.anonymityThreshold ?? 3,
+      templateId: input.templateId ?? null,
+      createdAt: now,
+      updatedAt: now,
+    })
+    .run();
+
+  return Number(result.lastInsertRowid);
+}
+```
+
+修改 `lib/evaluations/service.ts` 中的 `createEvaluationCycle`，在 survey 校验之后、插入之前，如果传了 `templateId`，校验模板存在性：
+
+```typescript
+import { getEvaluationTemplateById } from "./template-service";
+
+export async function createEvaluationCycle(input: EvaluationCycleInput) {
+  const parsed = evaluationCycleInputSchema.parse(input);
+  const survey = await getSurveyById(parsed.surveyId);
+  if (!survey) {
+    throw new ApiError(404, "问卷不存在");
+  }
+
+  if (parsed.templateId) {
+    const template = await getEvaluationTemplateById(parsed.templateId);
+    if (!template || template.status !== "active") {
+      throw new ApiError(404, "模板不存在或已归档");
+    }
+  }
+
+  const id = await insertEvaluationCycle(parsed);
+  return (await findEvaluationCycleById(id))!;
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run:
+```bash
+npx vitest run tests/lib/evaluations/service.test.ts -t "create cycle from template"
+```
+
+Expected: PASS。
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/evaluations/types.ts lib/evaluations/validators.ts lib/evaluations/repository.ts lib/evaluations/service.ts tests/lib/evaluations/service.test.ts
+git commit -m "feat(evaluations): support creating cycle from template
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: Template API Routes
+
+**Files:**
+- Create: `app/api/evaluation-templates/route.ts`
+- Create: `app/api/evaluation-templates/[id]/route.ts`
+- Create: `app/api/evaluation-templates/[id]/clone/route.ts`
+
+- [ ] **Step 1: Implement template list and create API**
+
+创建 `app/api/evaluation-templates/route.ts`：
+
+```typescript
+import { NextRequest } from "next/server";
+
+import { requireAdminSession } from "@/lib/auth/session";
+import { created, fromError, ok } from "@/lib/http/responses";
+import {
+  createEvaluationTemplate,
+  listEvaluationTemplates,
+} from "@/lib/evaluations/template-service";
+import { evaluationTemplateQuerySchema } from "@/lib/evaluations/template-validators";
+
+export async function GET(request: NextRequest) {
+  try {
+    await requireAdminSession();
+    const searchParams = request.nextUrl.searchParams;
+    const parsed = evaluationTemplateQuerySchema.parse({
+      builtin: searchParams.get("builtin") ?? undefined,
+    });
+    return ok(await listEvaluationTemplates(parsed));
+  } catch (error) {
+    return fromError(error);
+  }
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    await requireAdminSession();
+    return created(await createEvaluationTemplate(await request.json()));
+  } catch (error) {
+    return fromError(error);
+  }
+}
+```
+
+- [ ] **Step 2: Implement template detail, update, archive API**
+
+创建 `app/api/evaluation-templates/[id]/route.ts`：
+
+```typescript
+import { NextRequest } from "next/server";
+
+import { requireAdminSession } from "@/lib/auth/session";
+import { fromError, noContent, ok } from "@/lib/http/responses";
+import {
+  archiveEvaluationTemplate,
+  getEvaluationTemplateById,
+  updateEvaluationTemplate,
+} from "@/lib/evaluations/template-service";
+
+export async function GET(_request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  try {
+    await requireAdminSession();
+    const { id } = await params;
+    const template = await getEvaluationTemplateById(Number(id));
+    if (!template) {
+      return fromError({ status: 404, message: "模板不存在" });
+    }
+    return ok(template);
+  } catch (error) {
+    return fromError(error);
+  }
+}
+
+export async function PUT(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  try {
+    await requireAdminSession();
+    const { id } = await params;
+    return ok(await updateEvaluationTemplate(Number(id), await request.json()));
+  } catch (error) {
+    return fromError(error);
+  }
+}
+
+export async function DELETE(_request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  try {
+    await requireAdminSession();
+    const { id } = await params;
+    await archiveEvaluationTemplate(Number(id));
+    return noContent();
+  } catch (error) {
+    return fromError(error);
+  }
+}
+```
+
+- [ ] **Step 3: Implement clone API**
+
+创建 `app/api/evaluation-templates/[id]/clone/route.ts`：
+
+```typescript
+import { NextRequest } from "next/server";
+
+import { requireAdminSession } from "@/lib/auth/session";
+import { created, fromError } from "@/lib/http/responses";
+import { cloneEvaluationTemplate } from "@/lib/evaluations/template-service";
+
+export async function POST(_request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  try {
+    await requireAdminSession();
+    const { id } = await params;
+    return created(await cloneEvaluationTemplate(Number(id)));
+  } catch (error) {
+    return fromError(error);
+  }
+}
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/api/evaluation-templates/
+git commit -m "feat(api): add evaluation template management routes
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+## Task 7: Shared Components
+
+**Files:**
+- Create: `components/evaluations/anonymity-threshold-field.tsx`
+- Create: `components/evaluations/relationship-rule-builder.tsx`
+- Create: `components/evaluations/template-selector.tsx`
+- Create: `components/evaluations/template-form.tsx`
+
+- [ ] **Step 1: Implement AnonymityThresholdField**
+
+创建 `components/evaluations/anonymity-threshold-field.tsx`：
+
+```tsx
+import { Info } from "lucide-react";
+
+import {
+  HoverCard,
+  HoverCardContent,
+  HoverCardTrigger,
+} from "@/components/ui/hover-card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+
+interface AnonymityThresholdFieldProps {
+  value: number;
+  onChange: (value: number) => void;
+}
+
+export function AnonymityThresholdField({ value, onChange }: AnonymityThresholdFieldProps) {
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center gap-2">
+        <Label htmlFor="anonymity-threshold">匿名阈值</Label>
+        <HoverCard>
+          <HoverCardTrigger asChild>
+            <Info className="h-4 w-4 cursor-pointer text-muted-foreground" />
+          </HoverCardTrigger>
+          <HoverCardContent className="w-80">
+            <p className="text-sm">
+              匿名阈值用于保护评价者身份。当某个关系组（同级/下属/其他）的实际回收份数低于此数值时，该组的评分和评语将自动隐藏。自评和直属经理评价不受此限制，始终展示。
+            </p>
+          </HoverCardContent>
+        </HoverCard>
+      </div>
+      <Input
+        id="anonymity-threshold"
+        type="number"
+        min={1}
+        max={20}
+        value={value}
+        onChange={(e) => onChange(Number(e.target.value))}
+      />
+    </div>
+  );
+}
+```
+
+> 如果项目中不存在 `HoverCard` 组件，使用 `Tooltip` 替代或直接在字段下方显示 `p` 标签辅助文本。
+
+- [ ] **Step 2: Implement RelationshipRuleBuilder**
+
+创建 `components/evaluations/relationship-rule-builder.tsx`：
+
+```tsx
+import { Minus, Plus } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Label } from "@/components/ui/label";
+import type { RelationshipRule } from "@/lib/evaluations/template-types";
+
+const RELATIONSHIP_LABELS: Record<string, string> = {
+  self: "自评",
+  manager: "直属经理",
+  peer: "同级",
+  direct_report: "下属",
+  other: "其他",
+};
+
+interface RelationshipRuleBuilderProps {
+  rules: RelationshipRule[];
+  onChange: (rules: RelationshipRule[]) => void;
+}
+
+export function RelationshipRuleBuilder({ rules, onChange }: RelationshipRuleBuilderProps) {
+  const updateRule = (index: number, patch: Partial<RelationshipRule>) => {
+    const next = rules.map((r, i) => (i === index ? { ...r, ...patch } : r));
+    onChange(next);
+  };
+
+  return (
+    <div className="space-y-4">
+      <Label>评价关系规则</Label>
+      {rules.map((rule, index) => (
+        <div key={rule.type} className="flex items-center gap-4 rounded border p-3">
+          <span className="w-20 font-medium">{RELATIONSHIP_LABELS[rule.type]}</span>
+          <div className="flex items-center gap-2">
+            <Button
+              variant="outline"
+              size="icon"
+              type="button"
+              onClick={() => updateRule(index, { count: Math.max(0, rule.count - 1) })}
+            >
+              <Minus className="h-4 w-4" />
+            </Button>
+            <span className="w-8 text-center">{rule.count}</span>
+            <Button
+              variant="outline"
+              size="icon"
+              type="button"
+              onClick={() => updateRule(index, { count: Math.min(50, rule.count + 1) })}
+            >
+              <Plus className="h-4 w-4" />
+            </Button>
+          </div>
+          <div className="flex items-center gap-2">
+            <Checkbox
+              id={`required-${rule.type}`}
+              checked={rule.required}
+              onCheckedChange={(checked) => updateRule(index, { required: !!checked })}
+            />
+            <Label htmlFor={`required-${rule.type}`} className="text-sm font-normal">
+              必填
+            </Label>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 3: Implement TemplateSelector**
+
+创建 `components/evaluations/template-selector.tsx`：
+
+```tsx
+import { useEffect, useState } from "react";
+
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import type { EvaluationTemplate } from "@/lib/evaluations/template-types";
+
+interface TemplateSelectorProps {
+  value?: number;
+  onChange: (template: EvaluationTemplate | null) => void;
+}
+
+export function TemplateSelector({ value, onChange }: TemplateSelectorProps) {
+  const [templates, setTemplates] = useState<EvaluationTemplate[]>([]);
+
+  useEffect(() => {
+    fetch("/api/evaluation-templates")
+      .then((res) => res.json())
+      .then((data) => setTemplates(data.data ?? []));
+  }, []);
+
+  const handleChange = (id: string) => {
+    const template = templates.find((t) => t.id === Number(id));
+    onChange(template ?? null);
+  };
+
+  const builtin = templates.filter((t) => t.isBuiltin);
+  const custom = templates.filter((t) => !t.isBuiltin);
+
+  return (
+    <Select value={value?.toString()} onValueChange={handleChange}>
+      <SelectTrigger className="w-full">
+        <SelectValue placeholder="选择模板（可选）" />
+      </SelectTrigger>
+      <SelectContent>
+        {builtin.length > 0 && (
+          <SelectGroup>
+            <SelectLabel>系统模板</SelectLabel>
+            {builtin.map((t) => (
+              <SelectItem key={t.id} value={t.id.toString()}>
+                {t.name}
+              </SelectItem>
+            ))}
+          </SelectGroup>
+        )}
+        {custom.length > 0 && (
+          <SelectGroup>
+            <SelectLabel>我的模板</SelectLabel>
+            {custom.map((t) => (
+              <SelectItem key={t.id} value={t.id.toString()}>
+                {t.name}
+              </SelectItem>
+            ))}
+          </SelectGroup>
+        )}
+      </SelectContent>
+    </Select>
+  );
+}
+```
+
+- [ ] **Step 4: Implement TemplateForm**
+
+创建 `components/evaluations/template-form.tsx`：
+
+```tsx
+import { useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { AnonymityThresholdField } from "./anonymity-threshold-field";
+import { RelationshipRuleBuilder } from "./relationship-rule-builder";
+import type { EvaluationTemplate, RelationshipRule, TimeRule } from "@/lib/evaluations/template-types";
+
+const DEFAULT_RULES: RelationshipRule[] = [
+  { type: "self", count: 1, required: true },
+  { type: "manager", count: 1, required: true },
+  { type: "peer", count: 2, required: false },
+  { type: "direct_report", count: 3, required: false },
+];
+
+interface TemplateFormProps {
+  initial?: EvaluationTemplate | null;
+  onSubmit: (data: {
+    name: string;
+    description: string | null;
+    surveyId: number;
+    anonymityThreshold: number;
+    relationshipRules: RelationshipRule[];
+    timeRule: TimeRule;
+  }) => void;
+  loading?: boolean;
+}
+
+export function TemplateForm({ initial, onSubmit, loading }: TemplateFormProps) {
+  const [name, setName] = useState(initial?.name ?? "");
+  const [description, setDescription] = useState(initial?.description ?? "");
+  const [surveyId, setSurveyId] = useState(initial?.surveyId ?? 0);
+  const [anonymityThreshold, setAnonymityThreshold] = useState(
+    initial?.anonymityThreshold ?? 3
+  );
+  const [relationshipRules, setRelationshipRules] = useState<RelationshipRule[]>(
+    initial?.relationshipRules ?? DEFAULT_RULES
+  );
+  const [durationDays, setDurationDays] = useState(
+    initial?.timeRule?.durationDays ?? 14
+  );
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    onSubmit({
+      name,
+      description: description || null,
+      surveyId,
+      anonymityThreshold,
+      relationshipRules,
+      timeRule: { type: "relative", durationDays },
+    });
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-6">
+      <div className="space-y-2">
+        <Label htmlFor="name">模板名称</Label>
+        <Input id="name" value={name} onChange={(e) => setName(e.target.value)} required />
+      </div>
+      <div className="space-y-2">
+        <Label htmlFor="description">说明</Label>
+        <Textarea
+          id="description"
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+        />
+      </div>
+      <div className="space-y-2">
+        <Label htmlFor="survey-id">绑定问卷 ID</Label>
+        <Input
+          id="survey-id"
+          type="number"
+          value={surveyId || ""}
+          onChange={(e) => setSurveyId(Number(e.target.value))}
+          required
+        />
+      </div>
+      <AnonymityThresholdField value={anonymityThreshold} onChange={setAnonymityThreshold} />
+      <RelationshipRuleBuilder rules={relationshipRules} onChange={setRelationshipRules} />
+      <div className="space-y-2">
+        <Label htmlFor="duration">默认持续天数</Label>
+        <Input
+          id="duration"
+          type="number"
+          min={1}
+          value={durationDays}
+          onChange={(e) => setDurationDays(Number(e.target.value))}
+        />
+      </div>
+      <Button type="submit" disabled={loading}>
+        {loading ? "保存中..." : initial ? "更新模板" : "创建模板"}
+      </Button>
+    </form>
+  );
+}
+```
+
+> 如果项目中不存在 `Textarea` 组件，使用多行 `Input` 或原生 `textarea` 替代。
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add components/evaluations/anonymity-threshold-field.tsx components/evaluations/relationship-rule-builder.tsx components/evaluations/template-selector.tsx components/evaluations/template-form.tsx
+git commit -m "feat(ui): add template form components (selector, rule builder, threshold field)
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+## Task 8: Template Management Pages
+
+**Files:**
+- Create: `app/evaluations/templates/page.tsx`
+- Create: `app/evaluations/templates/new/page.tsx`
+- Create: `app/evaluations/templates/[id]/edit/page.tsx`
+
+- [ ] **Step 1: Implement template list page**
+
+创建 `app/evaluations/templates/page.tsx`：
+
+```tsx
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
+import { Copy, Pencil, Trash } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import type { EvaluationTemplate } from "@/lib/evaluations/template-types";
+
+export default function TemplatesPage() {
+  const router = useRouter();
+  const [templates, setTemplates] = useState<EvaluationTemplate[]>([]);
+
+  useEffect(() => {
+    fetch("/api/evaluation-templates")
+      .then((res) => res.json())
+      .then((data) => setTemplates(data.data ?? []));
+  }, []);
+
+  const handleClone = async (id: number) => {
+    const res = await fetch(`/api/evaluation-templates/${id}/clone`, { method: "POST" });
+    if (res.ok) {
+      const { data } = await res.json();
+      setTemplates((prev) => [...prev, data]);
+    }
+  };
+
+  const handleArchive = async (id: number) => {
+    if (!confirm("确定归档此模板？")) return;
+    const res = await fetch(`/api/evaluation-templates/${id}`, { method: "DELETE" });
+    if (res.ok) {
+      setTemplates((prev) => prev.filter((t) => t.id !== id));
+    }
+  };
+
+  return (
+    <div className="container mx-auto py-8">
+      <div className="mb-6 flex items-center justify-between">
+        <h1 className="text-2xl font-bold">评价模板管理</h1>
+        <Button onClick={() => router.push("/evaluations/templates/new")}>新建模板</Button>
+      </div>
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>名称</TableHead>
+            <TableHead>类型</TableHead>
+            <TableHead>匿名阈值</TableHead>
+            <TableHead>持续天数</TableHead>
+            <TableHead className="text-right">操作</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {templates.map((t) => (
+            <TableRow key={t.id}>
+              <TableCell>{t.name}</TableCell>
+              <TableCell>{t.isBuiltin ? "系统" : "自定义"}</TableCell>
+              <TableCell>{t.anonymityThreshold}</TableCell>
+              <TableCell>{t.timeRule.durationDays}</TableCell>
+              <TableCell className="text-right">
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  onClick={() => handleClone(t.id)}
+                  title="克隆"
+                >
+                  <Copy className="h-4 w-4" />
+                </Button>
+                {!t.isBuiltin && (
+                  <>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      onClick={() => router.push(`/evaluations/templates/${t.id}/edit`)}
+                      title="编辑"
+                    >
+                      <Pencil className="h-4 w-4" />
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      onClick={() => handleArchive(t.id)}
+                      title="归档"
+                    >
+                      <Trash className="h-4 w-4" />
+                    </Button>
+                  </>
+                )}
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Implement new template page**
+
+创建 `app/evaluations/templates/new/page.tsx`：
+
+```tsx
+"use client";
+
+import { useRouter } from "next/navigation";
+
+import { TemplateForm } from "@/components/evaluations/template-form";
+
+export default function NewTemplatePage() {
+  const router = useRouter();
+
+  const handleSubmit = async (data: Parameters<typeof TemplateForm>["onSubmit"] extends (d: infer T) => unknown ? T : never) => {
+    const res = await fetch("/api/evaluation-templates", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(data),
+    });
+    if (res.ok) {
+      router.push("/evaluations/templates");
+    } else {
+      alert("创建失败");
+    }
+  };
+
+  return (
+    <div className="container mx-auto max-w-2xl py-8">
+      <h1 className="mb-6 text-2xl font-bold">新建评价模板</h1>
+      <TemplateForm onSubmit={handleSubmit} />
+    </div>
+  );
+}
+```
+
+> 由于 `TemplateForm` 的 `onSubmit` 参数类型较复杂，可直接在页面中写内联类型或简化调用。
+
+- [ ] **Step 3: Implement edit template page**
+
+创建 `app/evaluations/templates/[id]/edit/page.tsx`：
+
+```tsx
+"use client";
+
+import { useParams, useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
+
+import { TemplateForm } from "@/components/evaluations/template-form";
+import type { EvaluationTemplate } from "@/lib/evaluations/template-types";
+
+export default function EditTemplatePage() {
+  const router = useRouter();
+  const params = useParams();
+  const id = Number(params.id);
+  const [template, setTemplate] = useState<EvaluationTemplate | null>(null);
+
+  useEffect(() => {
+    fetch(`/api/evaluation-templates/${id}`)
+      .then((res) => res.json())
+      .then((data) => setTemplate(data.data));
+  }, [id]);
+
+  const handleSubmit = async (data: {
+    name: string;
+    description: string | null;
+    surveyId: number;
+    anonymityThreshold: number;
+    relationshipRules: { type: string; count: number; required: boolean }[];
+    timeRule: { type: "relative"; durationDays: number };
+  }) => {
+    const res = await fetch(`/api/evaluation-templates/${id}`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(data),
+    });
+    if (res.ok) {
+      router.push("/evaluations/templates");
+    } else {
+      alert("更新失败");
+    }
+  };
+
+  if (!template) return <div>加载中...</div>;
+
+  return (
+    <div className="container mx-auto max-w-2xl py-8">
+      <h1 className="mb-6 text-2xl font-bold">编辑评价模板</h1>
+      <TemplateForm initial={template} onSubmit={handleSubmit} />
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/evaluations/templates/
+git commit -m "feat(pages): add template management UI (list, new, edit)
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+## Task 9: Modify Cycle Creation Page with Template Selector
+
+**Files:**
+- Modify: `app/evaluations/new/page.tsx`
+- Modify: `app/evaluations/[id]/page.tsx`
+
+- [ ] **Step 1: Add TemplateSelector to new cycle page**
+
+修改 `app/evaluations/new/page.tsx`，在表单顶部插入 `TemplateSelector`：
+
+```tsx
+// 在 imports 中添加
+import { TemplateSelector } from "@/components/evaluations/template-selector";
+import { AnonymityThresholdField } from "@/components/evaluations/anonymity-threshold-field";
+
+// 在组件 state 中添加
+const [selectedTemplate, setSelectedTemplate] = useState<EvaluationTemplate | null>(null);
+
+// 在表单 JSX 的最上方（标题下方）添加
+<div className="space-y-2">
+  <Label>使用模板</Label>
+  <TemplateSelector value={selectedTemplate?.id} onChange={(template) => {
+    setSelectedTemplate(template);
+    if (template) {
+      setTitle(`${template.name}（${new Date().getFullYear()}）`);
+      setSurveyId(template.surveyId);
+      setAnonymityThreshold(template.anonymityThreshold);
+      const today = new Date();
+      const end = new Date(today);
+      end.setDate(today.getDate() + template.timeRule.durationDays);
+      setStartsAt(formatDate(today));
+      setEndsAt(formatDate(end));
+    }
+  }} />
+</div>
+```
+
+同时，将表单中原有的匿名阈值输入替换为 `AnonymityThresholdField`：
+
+```tsx
+<AnonymityThresholdField value={anonymityThreshold} onChange={setAnonymityThreshold} />
+```
+
+并在提交时传入 `templateId`：
+
+```tsx
+const handleSubmit = async (e: React.FormEvent) => {
+  e.preventDefault();
+  // ...
+  const payload = {
+    title,
+    description: description || null,
+    surveyId: Number(surveyId),
+    startsAt: startsAt ? new Date(startsAt).getTime() / 1000 : null,
+    endsAt: endsAt ? new Date(endsAt).getTime() / 1000 : null,
+    anonymityThreshold,
+    templateId: selectedTemplate?.id ?? null,
+  };
+  // ...
+};
+```
+
+> 需要仔细阅读 `app/evaluations/new/page.tsx` 的现有实现，将上述改动融入现有代码，不要破坏原有结构。
+
+- [ ] **Step 2: Add template provenance to cycle detail page**
+
+修改 `app/evaluations/[id]/page.tsx`，在周期标题附近添加溯源标签：
+
+```tsx
+// 在展示周期信息的区域，如果 cycle.templateId 存在，显示
+{cycle.templateId && (
+  <span className="ml-2 inline-flex items-center rounded-full bg-blue-50 px-2 py-0.5 text-xs font-medium text-blue-700">
+    基于模板
+  </span>
+)}
+```
+
+> 如果 cycle 对象中没有 `templateId` 字段，需要确认 API 返回的数据结构。
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/evaluations/new/page.tsx app/evaluations/[id]/page.tsx
+git commit -m "feat(ui): integrate template selector into cycle creation, show provenance on detail
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+## Task 10: E2E Tests
+
+**Files:**
+- Create: `tests/e2e/evaluation-template.spec.ts`
+
+- [ ] **Step 1: Write E2E tests**
+
+创建 `tests/e2e/evaluation-template.spec.ts`：
+
+```typescript
+import { expect, test } from "@playwright/test";
+
+test.describe("evaluation templates", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/login");
+    // 登录逻辑（根据现有 E2E 测试的登录 helper 调整）
+  });
+
+  test("should create and use a template", async ({ page }) => {
+    // 1. 创建问卷
+    await page.goto("/surveys/new");
+    await page.fill('input[name="title"]', "360 测试问卷");
+    await page.click('button[type="submit"]');
+    await page.waitForURL(/\/surveys\/\d+/);
+    const surveyUrl = page.url();
+    const surveyId = Number(surveyUrl.match(/\/surveys\/(\d+)/)![1]);
+
+    // 2. 创建模板
+    await page.goto("/evaluations/templates/new");
+    await page.fill('input[id="name"]', "E2E 测试模板");
+    await page.fill('input[id="survey-id"]', surveyId.toString());
+    await page.click('button[type="submit"]');
+    await page.waitForURL("/evaluations/templates");
+    await expect(page.locator("text=E2E 测试模板")).toBeVisible();
+
+    // 3. 克隆模板
+    await page.click('button[title="克隆"]');
+    await expect(page.locator("text=E2E 测试模板 副本")).toBeVisible();
+
+    // 4. 使用模板创建周期
+    await page.goto("/evaluations/new");
+    await page.click('[placeholder="选择模板（可选）"]');
+    await page.click('text=E2E 测试模板');
+    await expect(page.locator('input[name="title"]')).toHaveValue(/E2E 测试模板/);
+
+    // 5. 提交创建
+    await page.click('button[type="submit"]');
+    await page.waitForURL(/\/evaluations\/\d+/);
+    await expect(page.locator("text=基于模板")).toBeVisible();
+  });
+});
+```
+
+> 上述选择器需要根据实际 UI 组件调整。如果 `Select` 组件的交互方式不同，使用 Playwright 的 `selectOption` 或点击方式适配。
+
+- [ ] **Step 2: Run E2E tests**
+
+Run:
+```bash
+npx playwright test tests/e2e/evaluation-template.spec.ts
+```
+
+Expected: 根据实际环境可能 PASS 或需要调整选择器。
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/e2e/evaluation-template.spec.ts
+git commit -m "test(e2e): add evaluation template workflow tests
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+## Self-Review Checklist
+
+### 1. Spec Coverage
+
+| Spec 需求 | 对应 Task |
+|---|---|
+| 新增 `evaluation_templates` 表 | Task 1 |
+| `evaluation_cycles` 新增 `template_id` | Task 1, 5 |
+| 模板 CRUD API | Task 3, 4, 6 |
+| 模板克隆 | Task 4, 6 |
+| 模板归档（软删除） | Task 3, 4, 6 |
+| 系统内置模板不可编辑/归档 | Task 4 |
+| 周期创建支持 `template_id` | Task 5 |
+| 创建周期时模板自动回填 | Task 9 |
+| 模板管理页面（列表/新建/编辑） | Task 8 |
+| 匿名阈值说明文案 | Task 7 |
+| 周期详情页溯源标签 | Task 9 |
+| 测试覆盖 | Task 3, 4, 5, 10 |
+
+**Gap:** 系统内置模板的初始 seed 数据未在计划中体现。应在 Task 1 之后补充一个 seed 脚本，或在内置模板逻辑中允许 Admin 手动创建后再标记为内置。
+
+### 2. Placeholder Scan
+
+- [x] 无 "TBD" / "TODO" / "implement later"
+- [x] 无 "Add appropriate error handling" 等模糊描述
+- [x] 每个代码步骤包含完整代码
+- [x] 无 "Similar to Task N" 引用
+
+### 3. Type Consistency
+
+- [x] `EvaluationTemplateInput` 类型与 `evaluationTemplateInputSchema` 对齐
+- [x] `EvaluationCycleInput` 与 `evaluationCycleInputSchema` 的 `templateId` 字段一致
+- [x] `parseTemplateRow` 中的 JSON parse 类型与 `RelationshipRule[]`、`TimeRule` 对齐
+- [x] API 路由中的 `params` 使用 Next.js 15 的 `Promise<{ id: string }>` 模式
+
+---
+
+## Execution Handoff
+
+Plan complete and saved to `docs/superpowers/plans/2026-04-27-evaluation-template-implementation.md`.
+
+**Two execution options:**
+
+**1. Subagent-Driven (recommended)** - I dispatch a fresh subagent per task, review between tasks, fast iteration
+
+**2. Inline Execution** - Execute tasks in this session using executing-plans, batch execution with checkpoints
+
+Which approach?

--- a/docs/superpowers/specs/2026-04-27-evaluation-template-design.md
+++ b/docs/superpowers/specs/2026-04-27-evaluation-template-design.md
@@ -1,0 +1,206 @@
+# 360 环评模板系统设计文档
+
+## 目的
+
+将 360 环评从「每次手动配置」升级为「基于模板一键发起」，降低使用门槛，统一组织评价标准，解决当前系统"太 demo"、缺乏运营闭环的问题。
+
+## 背景
+
+当前 360 环评每次创建周期时，HR/Admin 需要手动完成以下配置：
+- 选择问卷
+- 填写标题和描述
+- 设置匿名阈值
+- 配置评价关系规则（自评、经理、同级、下属等）
+- 设置起止时间
+
+这些配置在同类评价活动中高度重复，且没有标准可循，导致发起效率低、评价标准不统一。模板系统通过预置配置快照，实现「一键发起」。
+
+## 方案概述
+
+采用**结构化规则模板（方案 B）**：独立 `evaluation_templates` 表存储模板元数据和规则配置，支持系统内置模板和管理员自定义模板，创建周期时可选择模板自动回填所有配置字段。
+
+## 数据模型
+
+### 新增表：`evaluation_templates`
+
+| 字段 | 类型 | 约束 | 说明 |
+|---|---|---|---|
+| `id` | INTEGER | PRIMARY KEY AUTOINCREMENT | 自增 ID |
+| `name` | TEXT | NOT NULL | 模板名称，如"季度员工 360" |
+| `description` | TEXT | | 模板说明 |
+| `survey_id` | INTEGER | NOT NULL → surveys(id) ON DELETE RESTRICT | 绑定的问卷 |
+| `anonymity_threshold` | INTEGER | DEFAULT 3 NOT NULL | 匿名阈值 |
+| `relationship_rules` | TEXT | NOT NULL (JSON) | 评价关系规则数组 |
+| `time_rule` | TEXT | NOT NULL (JSON) | 时间规则 |
+| `is_builtin` | INTEGER | DEFAULT 0 NOT NULL | 1=系统内置，0=用户自定义 |
+| `created_by` | INTEGER | → users(id) ON DELETE SET NULL | 自定义模板的创建人，系统模板为 NULL |
+| `status` | TEXT | DEFAULT 'active' NOT NULL | active / archived |
+| `created_at` | INTEGER | DEFAULT (unixepoch()) NOT NULL | |
+| `updated_at` | INTEGER | DEFAULT (unixepoch()) NOT NULL | |
+
+### `relationship_rules` JSON 结构
+
+```json
+[
+  { "type": "self", "count": 1, "required": true },
+  { "type": "manager", "count": 1, "required": true },
+  { "type": "peer", "count": 2, "required": false },
+  { "type": "direct_report", "count": 3, "required": false }
+]
+```
+
+- `type` 枚举值：self / manager / peer / direct_report / other
+- `count`：该关系类型下期望的评价人数
+- `required`：是否为必填项（影响批量分配时的行为）
+
+### `time_rule` JSON 结构（V1）
+
+```json
+{ "type": "relative", "duration_days": 14 }
+```
+
+- `type` 当前仅支持 `relative`，未来可扩展 `fixed`
+- `duration_days`：周期默认持续天数，从表单打开当天起算（HR 可手动覆盖）
+
+### 现有表改动
+
+**`evaluation_cycles` 表**
+
+新增字段：
+
+| 字段 | 类型 | 约束 | 说明 |
+|---|---|---|---|
+| `template_id` | INTEGER | → evaluation_templates(id) ON DELETE SET NULL | 记录基于哪个模板创建，用于溯源 |
+
+## 用户流程
+
+### 使用模板创建周期
+
+1. HR 进入「360 管理」→ 点击「新建周期」
+2. 页面顶部出现「使用模板」下拉框（可选）
+   - 下拉选项按 `is_builtin DESC, updated_at DESC` 排序
+   - 系统内置模板带「系统」标签
+   - 用户自定义模板带创建人姓名
+3. 选择模板后，表单自动回填：
+   - 标题：模板名称 + 时间后缀（如"季度员工 360（2026 Q2）"）
+   - 问卷：模板绑定的问卷
+   - 匿名阈值：模板预设值
+   - 起止时间：根据 `time_rule` 自动计算（今天起 + duration_days）
+   - 关系规则：可视化展示在表单中（只读预览，创建周期后执行批量分配）
+4. HR 可手动调整任何字段（模板是快照，不是绑定）
+5. 保存后周期进入 `draft` 状态，可立即「批量生成评价关系」
+
+### 管理模板
+
+1. 新增「模板管理」页面，作为「360 管理」的子入口
+2. 列表展示所有 `status = active` 的模板
+3. 操作：
+   - **新建模板**：进入模板编辑表单
+   - **编辑模板**：修改现有自定义模板（系统模板不可编辑，但可克隆）
+   - **克隆模板**：基于任意模板创建副本，名称自动加"副本"
+   - **归档模板**：软删除（status → archived）
+4. 模板表单字段与创建周期表单类似，但不包含「主题」「起止时间」
+
+## API 设计
+
+### 模板管理接口
+
+| 方法 | 路由 | 功能 | 权限 |
+|---|---|---|---|
+| GET | `/api/evaluation-templates` | 模板列表，支持 `?builtin=true/false` 筛选 | Admin |
+| POST | `/api/evaluation-templates` | 新建模板 | Admin |
+| GET | `/api/evaluation-templates/[id]` | 模板详情 | Admin |
+| PUT | `/api/evaluation-templates/[id]` | 编辑模板（仅限非系统模板） | Admin |
+| POST | `/api/evaluation-templates/[id]/clone` | 克隆模板 | Admin |
+| DELETE | `/api/evaluation-templates/[id]` | 归档模板 | Admin |
+
+### 周期创建接口增强
+
+`POST /api/evaluations` 请求体新增可选字段：
+
+```json
+{
+  "template_id": 1,
+  "title": "季度员工 360（2026 Q2）",
+  "survey_id": 2,
+  "anonymity_threshold": 3,
+  "starts_at": "2026-04-27",
+  "ends_at": "2026-05-11"
+}
+```
+
+如果提供了 `template_id`，后端校验模板存在且 active，将模板字段作为默认值，请求体中的其他字段可覆盖模板值。
+
+## 页面与组件
+
+### 新增页面
+
+| 页面 | 路径 | 说明 |
+|---|---|---|
+| 模板列表 | `/evaluations/templates` | 表格展示，支持搜索/筛选 |
+| 新建模板 | `/evaluations/templates/new` | 模板编辑表单 |
+| 编辑模板 | `/evaluations/templates/[id]/edit` | 模板编辑表单 |
+
+### 现有页面改动
+
+| 页面 | 改动 |
+|---|---|
+| `/evaluations/new` | 顶部新增 `TemplateSelector` 组件，选模板后自动回填表单字段 |
+| `/evaluations/[id]` | 如果 `template_id` 存在，在页面头部显示「基于模板：XXX」溯源标签 |
+| `/evaluations` | 可选：列表中增加「模板来源」列 |
+
+### 新增/复用组件
+
+- `TemplateSelector`：模板下拉选择器，按系统/自定义分组展示
+- `TemplateForm`：模板编辑表单（复用周期创建表单的基础字段）
+- `RelationshipRulePreview`：关系规则只读预览组件（在行创建周期页展示模板中的规则）
+- `AnonymityThresholdField`：匿名阈值输入框 + 说明文案（复用到周期和模板表单）
+
+## 匿名阈值说明文案
+
+在「创建周期」和「模板编辑」表单的 `anonymity_threshold` 字段旁，显示辅助说明：
+
+> 「匿名阈值用于保护评价者身份。当某个关系组（同级/下属/其他）的实际回收份数低于此数值时，该组的评分和评语将自动隐藏。自评和直属经理评价不受此限制，始终展示。」
+
+## 系统内置模板（初始数据）
+
+| 名称 | 问卷 | 阈值 | 关系规则 | 时间规则 |
+|---|---|---|---|---|
+| 季度员工 360 | 默认 360 问卷 | 3 | 自评×1, 经理×1, 同级×2, 下属×3 | 14 天 |
+| 年度管理层 360 | 领导力 360 问卷 | 5 | 自评×1, 经理×1, 同级×3, 下属×5 | 21 天 |
+
+> 注：系统内置模板通过 migration seed 或初始化脚本写入，字段 `is_builtin = 1, created_by = NULL`。若系统不存在对应问卷，首批内置模板可只创建元数据、问卷字段留空，由 Admin 首次使用时手动绑定；或在初始化脚本中同时创建默认问卷。
+
+## 安全与权限
+
+- 模板管理仅限 Admin 角色访问
+- 系统内置模板（`is_builtin = 1`）不可编辑、不可删除，仅可克隆
+- 自定义模板只能由创建者或 Admin 编辑/归档
+- 归档后的模板不在下拉选择器中展示
+- 周期创建时传入的 `template_id` 后端校验存在性、active 状态、可见性
+
+## 测试要点
+
+1. **API 测试**：模板 CRUD、克隆、归档、基于模板创建周期的字段回填逻辑
+2. **UI 测试**：模板选择器回填、表单覆盖、系统模板禁用编辑
+3. **边界测试**：使用 archived 模板创建周期（应失败）、编辑系统模板（应失败）、匿名阈值范围校验（≥1）
+4. **E2E 测试**：基于模板一键发起完整 360 周期并走完评价流程
+
+## 影响与风险
+
+| 影响点 | 说明 |
+|---|---|
+| 数据库 | 新增 1 张表，现有表新增 1 个字段，需写 migration |
+| 现有功能 | 周期创建接口新增可选字段，向后兼容；不选模板时行为不变 |
+| 权限模型 | 依赖现有 Admin 角色判断，无新增角色 |
+| 性能 | 模板数据量极小（通常 < 100 条），无性能风险 |
+
+## 验收标准
+
+- [ ] Admin 可以在「模板管理」页面新建、编辑、克隆、归档模板
+- [ ] 创建 360 周期时，可以通过下拉框选择模板，表单自动回填所有配置
+- [ ] 选择模板后仍可手动修改任何字段
+- [ ] 系统内置模板不可编辑，但可克隆为自定义模板
+- [ ] 周期详情页显示基于哪个模板创建（如有）
+- [ ] 匿名阈值字段旁有说明文案
+- [ ] 所有现有 360 功能不受模板系统影响（不选模板时行为完全一致）

--- a/drizzle/0002_evaluation_templates.sql
+++ b/drizzle/0002_evaluation_templates.sql
@@ -1,0 +1,18 @@
+CREATE TABLE `evaluation_templates` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`name` text NOT NULL,
+	`description` text,
+	`survey_id` integer NOT NULL,
+	`anonymity_threshold` integer DEFAULT 3 NOT NULL,
+	`relationship_rules` text NOT NULL,
+	`time_rule` text NOT NULL,
+	`is_builtin` integer DEFAULT false NOT NULL,
+	`created_by` integer,
+	`status` text DEFAULT 'active' NOT NULL,
+	`created_at` integer DEFAULT (unixepoch()) NOT NULL,
+	`updated_at` integer DEFAULT (unixepoch()) NOT NULL,
+	FOREIGN KEY (`survey_id`) REFERENCES `surveys`(`id`) ON UPDATE no action ON DELETE restrict,
+	FOREIGN KEY (`created_by`) REFERENCES `employees`(`id`) ON UPDATE no action ON DELETE set null
+);
+--> statement-breakpoint
+ALTER TABLE `evaluation_cycles` ADD `template_id` integer REFERENCES evaluation_templates(id);

--- a/drizzle/meta/0002_snapshot.json
+++ b/drizzle/meta/0002_snapshot.json
@@ -1,0 +1,883 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "758117a7-054e-4df9-ab49-bb17fd8a953f",
+  "prevId": "9096fb55-2126-4bd7-8f9c-3c3c61f89bdd",
+  "tables": {
+    "employees": {
+      "name": "employees",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "employee_no": {
+          "name": "employee_no",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "department": {
+          "name": "department",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "manager_id": {
+          "name": "manager_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "employees_employee_no_unique": {
+          "name": "employees_employee_no_unique",
+          "columns": [
+            "employee_no"
+          ],
+          "isUnique": true
+        },
+        "employees_email_unique": {
+          "name": "employees_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        },
+        "employees_name_idx": {
+          "name": "employees_name_idx",
+          "columns": [
+            "name"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "employees_manager_id_employees_id_fk": {
+          "name": "employees_manager_id_employees_id_fk",
+          "tableFrom": "employees",
+          "tableTo": "employees",
+          "columnsFrom": [
+            "manager_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "evaluation_assignments": {
+      "name": "evaluation_assignments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "cycle_id": {
+          "name": "cycle_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "subject_id": {
+          "name": "subject_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rater_employee_id": {
+          "name": "rater_employee_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "relationship": {
+          "name": "relationship",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "response_id": {
+          "name": "response_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "evaluation_assignments_token_unique": {
+          "name": "evaluation_assignments_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "evaluation_assignments_token_idx": {
+          "name": "evaluation_assignments_token_idx",
+          "columns": [
+            "token"
+          ],
+          "isUnique": false
+        },
+        "evaluation_assignments_subject_idx": {
+          "name": "evaluation_assignments_subject_idx",
+          "columns": [
+            "subject_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "evaluation_assignments_cycle_id_evaluation_cycles_id_fk": {
+          "name": "evaluation_assignments_cycle_id_evaluation_cycles_id_fk",
+          "tableFrom": "evaluation_assignments",
+          "tableTo": "evaluation_cycles",
+          "columnsFrom": [
+            "cycle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "evaluation_assignments_subject_id_evaluation_subjects_id_fk": {
+          "name": "evaluation_assignments_subject_id_evaluation_subjects_id_fk",
+          "tableFrom": "evaluation_assignments",
+          "tableTo": "evaluation_subjects",
+          "columnsFrom": [
+            "subject_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "evaluation_assignments_rater_employee_id_employees_id_fk": {
+          "name": "evaluation_assignments_rater_employee_id_employees_id_fk",
+          "tableFrom": "evaluation_assignments",
+          "tableTo": "employees",
+          "columnsFrom": [
+            "rater_employee_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "evaluation_assignments_response_id_survey_responses_id_fk": {
+          "name": "evaluation_assignments_response_id_survey_responses_id_fk",
+          "tableFrom": "evaluation_assignments",
+          "tableTo": "survey_responses",
+          "columnsFrom": [
+            "response_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "evaluation_cycles": {
+      "name": "evaluation_cycles",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'draft'"
+        },
+        "survey_id": {
+          "name": "survey_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "starts_at": {
+          "name": "starts_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ends_at": {
+          "name": "ends_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "anonymity_threshold": {
+          "name": "anonymity_threshold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 3
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "evaluation_cycles_survey_id_surveys_id_fk": {
+          "name": "evaluation_cycles_survey_id_surveys_id_fk",
+          "tableFrom": "evaluation_cycles",
+          "tableTo": "surveys",
+          "columnsFrom": [
+            "survey_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "evaluation_cycles_template_id_evaluation_templates_id_fk": {
+          "name": "evaluation_cycles_template_id_evaluation_templates_id_fk",
+          "tableFrom": "evaluation_cycles",
+          "tableTo": "evaluation_templates",
+          "columnsFrom": [
+            "template_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "evaluation_subjects": {
+      "name": "evaluation_subjects",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "cycle_id": {
+          "name": "cycle_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "employee_id": {
+          "name": "employee_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "evaluation_subjects_cycle_employee_unique": {
+          "name": "evaluation_subjects_cycle_employee_unique",
+          "columns": [
+            "cycle_id",
+            "employee_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "evaluation_subjects_cycle_id_evaluation_cycles_id_fk": {
+          "name": "evaluation_subjects_cycle_id_evaluation_cycles_id_fk",
+          "tableFrom": "evaluation_subjects",
+          "tableTo": "evaluation_cycles",
+          "columnsFrom": [
+            "cycle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "evaluation_subjects_employee_id_employees_id_fk": {
+          "name": "evaluation_subjects_employee_id_employees_id_fk",
+          "tableFrom": "evaluation_subjects",
+          "tableTo": "employees",
+          "columnsFrom": [
+            "employee_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "evaluation_templates": {
+      "name": "evaluation_templates",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "survey_id": {
+          "name": "survey_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "anonymity_threshold": {
+          "name": "anonymity_threshold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 3
+        },
+        "relationship_rules": {
+          "name": "relationship_rules",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "time_rule": {
+          "name": "time_rule",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_builtin": {
+          "name": "is_builtin",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "evaluation_templates_survey_id_surveys_id_fk": {
+          "name": "evaluation_templates_survey_id_surveys_id_fk",
+          "tableFrom": "evaluation_templates",
+          "tableTo": "surveys",
+          "columnsFrom": [
+            "survey_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "evaluation_templates_created_by_employees_id_fk": {
+          "name": "evaluation_templates_created_by_employees_id_fk",
+          "tableFrom": "evaluation_templates",
+          "tableTo": "employees",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "survey_options": {
+      "name": "survey_options",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "order_index": {
+          "name": "order_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "survey_options_question_id_survey_questions_id_fk": {
+          "name": "survey_options_question_id_survey_questions_id_fk",
+          "tableFrom": "survey_options",
+          "tableTo": "survey_questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "survey_questions": {
+      "name": "survey_questions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "survey_id": {
+          "name": "survey_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "required": {
+          "name": "required",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "order_index": {
+          "name": "order_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "config": {
+          "name": "config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "survey_questions_survey_id_surveys_id_fk": {
+          "name": "survey_questions_survey_id_surveys_id_fk",
+          "tableFrom": "survey_questions",
+          "tableTo": "surveys",
+          "columnsFrom": [
+            "survey_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "survey_responses": {
+      "name": "survey_responses",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "survey_id": {
+          "name": "survey_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "answers": {
+          "name": "answers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "respondent_id": {
+          "name": "respondent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "duration_seconds": {
+          "name": "duration_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "survey_responses_survey_id_surveys_id_fk": {
+          "name": "survey_responses_survey_id_surveys_id_fk",
+          "tableFrom": "survey_responses",
+          "tableTo": "surveys",
+          "columnsFrom": [
+            "survey_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "surveys": {
+      "name": "surveys",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'draft'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1777206725972,
       "tag": "0001_employee_360_review",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "6",
+      "when": 1777278925262,
+      "tag": "0002_evaluation_templates",
+      "breakpoints": true
     }
   ]
 }

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -121,6 +121,27 @@ export const employees = sqliteTable(
   ],
 );
 
+export const evaluationTemplates = sqliteTable("evaluation_templates", {
+  id: integer("id").primaryKey({ autoIncrement: true }),
+  name: text("name").notNull(),
+  description: text("description"),
+  surveyId: integer("survey_id")
+    .notNull()
+    .references(() => surveys.id, { onDelete: "restrict" }),
+  anonymityThreshold: integer("anonymity_threshold").notNull().default(3),
+  relationshipRules: text("relationship_rules").notNull(),
+  timeRule: text("time_rule").notNull(),
+  isBuiltin: integer("is_builtin", { mode: "boolean" }).notNull().default(false),
+  createdBy: integer("created_by").references(() => employees.id, {
+    onDelete: "set null",
+  }),
+  status: text("status", { enum: ["active", "archived"] })
+    .notNull()
+    .default("active"),
+  createdAt: integer("created_at").notNull().default(sql`(unixepoch())`),
+  updatedAt: integer("updated_at").notNull().default(sql`(unixepoch())`),
+});
+
 export const evaluationCycles = sqliteTable("evaluation_cycles", {
   id: integer("id").primaryKey({ autoIncrement: true }),
   title: text("title").notNull(),
@@ -134,6 +155,9 @@ export const evaluationCycles = sqliteTable("evaluation_cycles", {
   startsAt: integer("starts_at"),
   endsAt: integer("ends_at"),
   anonymityThreshold: integer("anonymity_threshold").notNull().default(3),
+  templateId: integer("template_id").references(() => evaluationTemplates.id, {
+    onDelete: "set null",
+  }),
   createdAt: integer("created_at").notNull().default(sql`(unixepoch())`),
   updatedAt: integer("updated_at").notNull().default(sql`(unixepoch())`),
 });

--- a/lib/evaluations/repository.ts
+++ b/lib/evaluations/repository.ts
@@ -30,6 +30,7 @@ export async function insertEvaluationCycle(
       startsAt: input.startsAt ?? null,
       endsAt: input.endsAt ?? null,
       anonymityThreshold: input.anonymityThreshold ?? 3,
+      templateId: input.templateId ?? null,
       createdAt: now,
       updatedAt: now,
     })

--- a/lib/evaluations/service.ts
+++ b/lib/evaluations/service.ts
@@ -29,6 +29,7 @@ import {
   evaluationCycleInputSchema,
 } from "@/lib/evaluations/validators";
 import { getSurveyById } from "@/lib/surveys/service";
+import { getEvaluationTemplateById } from "./template-service";
 import { submitResponsePayloadSchema, validateAnswersAgainstSurvey } from "@/lib/surveys/validators";
 import { sanitizePlainText } from "@/lib/security/sanitize";
 import type { SurveyAnswerValue } from "@/lib/surveys/types";
@@ -54,6 +55,14 @@ export async function createEvaluationCycle(input: EvaluationCycleInput) {
   if (!survey) {
     throw new ApiError(404, "问卷不存在");
   }
+
+  if (parsed.templateId) {
+    const template = await getEvaluationTemplateById(parsed.templateId);
+    if (!template || template.status !== "active") {
+      throw new ApiError(404, "模板不存在或已归档");
+    }
+  }
+
   const id = await insertEvaluationCycle(parsed);
   return (await findEvaluationCycleById(id))!;
 }

--- a/lib/evaluations/template-repository.ts
+++ b/lib/evaluations/template-repository.ts
@@ -1,0 +1,91 @@
+import { and, eq } from "drizzle-orm";
+
+import { db } from "@/lib/db/client";
+import { evaluationTemplates } from "@/lib/db/schema";
+
+export async function insertEvaluationTemplate(data: {
+  name: string;
+  description: string | null;
+  surveyId: number;
+  anonymityThreshold: number;
+  relationshipRules: string;
+  timeRule: string;
+  isBuiltin: boolean;
+  createdBy: number | null;
+}): Promise<number> {
+  const now = Math.floor(Date.now() / 1000);
+  const result = db
+    .insert(evaluationTemplates)
+    .values({
+      name: data.name,
+      description: data.description,
+      surveyId: data.surveyId,
+      anonymityThreshold: data.anonymityThreshold,
+      relationshipRules: data.relationshipRules,
+      timeRule: data.timeRule,
+      isBuiltin: data.isBuiltin,
+      createdBy: data.createdBy,
+      status: "active",
+      createdAt: now,
+      updatedAt: now,
+    })
+    .run();
+
+  return Number(result.lastInsertRowid);
+}
+
+export async function findEvaluationTemplateById(id: number) {
+  return db
+    .select()
+    .from(evaluationTemplates)
+    .where(eq(evaluationTemplates.id, id))
+    .get();
+}
+
+export async function listEvaluationTemplates(filters?: { builtin?: boolean }) {
+  const conditions = [eq(evaluationTemplates.status, "active")];
+  if (filters?.builtin !== undefined) {
+    conditions.push(eq(evaluationTemplates.isBuiltin, filters.builtin));
+  }
+
+  return db
+    .select()
+    .from(evaluationTemplates)
+    .where(and(...conditions))
+    .orderBy(evaluationTemplates.isBuiltin, evaluationTemplates.updatedAt)
+    .all();
+}
+
+export async function updateEvaluationTemplate(
+  id: number,
+  data: {
+    name: string;
+    description: string | null;
+    surveyId: number;
+    anonymityThreshold: number;
+    relationshipRules: string;
+    timeRule: string;
+  }
+) {
+  const now = Math.floor(Date.now() / 1000);
+  db.update(evaluationTemplates)
+    .set({
+      name: data.name,
+      description: data.description,
+      surveyId: data.surveyId,
+      anonymityThreshold: data.anonymityThreshold,
+      relationshipRules: data.relationshipRules,
+      timeRule: data.timeRule,
+      updatedAt: now,
+    })
+    .where(eq(evaluationTemplates.id, id))
+    .run();
+}
+
+export async function archiveEvaluationTemplate(id: number) {
+  const now = Math.floor(Date.now() / 1000);
+  db.update(evaluationTemplates)
+    .set({ status: "archived", updatedAt: now })
+    .where(eq(evaluationTemplates.id, id))
+    .run();
+}

--- a/lib/evaluations/template-service.ts
+++ b/lib/evaluations/template-service.ts
@@ -1,0 +1,125 @@
+import { ApiError } from "@/lib/http/api-error";
+import { getSurveyById } from "@/lib/surveys/service";
+import {
+  archiveEvaluationTemplate as archiveTemplateRepo,
+  findEvaluationTemplateById,
+  insertEvaluationTemplate,
+  listEvaluationTemplates as listTemplatesRepo,
+  updateEvaluationTemplate as updateTemplateRepo,
+} from "./template-repository";
+import type {
+  EvaluationTemplate,
+  EvaluationTemplateInput,
+  RelationshipRule,
+  TimeRule,
+} from "./template-types";
+import { evaluationTemplateInputSchema } from "./template-validators";
+
+function parseTemplateRow(row: {
+  relationshipRules: string;
+  timeRule: string;
+  [key: string]: unknown;
+}): Omit<typeof row, "relationshipRules" | "timeRule"> & {
+  relationshipRules: RelationshipRule[];
+  timeRule: TimeRule;
+} {
+  const { relationshipRules, timeRule, ...rest } = row;
+  return {
+    ...rest,
+    relationshipRules: JSON.parse(relationshipRules) as RelationshipRule[],
+    timeRule: JSON.parse(timeRule) as TimeRule,
+  };
+}
+
+export async function createEvaluationTemplate(
+  input: EvaluationTemplateInput & { isBuiltin?: boolean; createdBy?: number | null }
+): Promise<EvaluationTemplate> {
+  const parsed = evaluationTemplateInputSchema.parse(input);
+  const survey = await getSurveyById(parsed.surveyId);
+  if (!survey) {
+    throw new ApiError(404, "问卷不存在");
+  }
+
+  const id = await insertEvaluationTemplate({
+    name: parsed.name,
+    description: parsed.description ?? null,
+    surveyId: parsed.surveyId,
+    anonymityThreshold: parsed.anonymityThreshold,
+    relationshipRules: JSON.stringify(parsed.relationshipRules),
+    timeRule: JSON.stringify(parsed.timeRule),
+    isBuiltin: input.isBuiltin ?? false,
+    createdBy: input.createdBy ?? null,
+  });
+
+  const row = await findEvaluationTemplateById(id);
+  return parseTemplateRow(row!) as EvaluationTemplate;
+}
+
+export async function getEvaluationTemplateById(id: number): Promise<EvaluationTemplate | null> {
+  const row = await findEvaluationTemplateById(id);
+  if (!row) return null;
+  return parseTemplateRow(row) as EvaluationTemplate;
+}
+
+export async function listEvaluationTemplates(filters?: { builtin?: boolean }): Promise<EvaluationTemplate[]> {
+  const rows = await listTemplatesRepo(filters);
+  return rows.map((row) => parseTemplateRow(row) as EvaluationTemplate);
+}
+
+export async function updateEvaluationTemplate(
+  id: number,
+  input: EvaluationTemplateInput
+): Promise<EvaluationTemplate> {
+  const existing = await findEvaluationTemplateById(id);
+  if (!existing) {
+    throw new ApiError(404, "模板不存在");
+  }
+  if (existing.isBuiltin) {
+    throw new ApiError(403, "系统内置模板不能编辑");
+  }
+
+  const parsed = evaluationTemplateInputSchema.parse(input);
+  const survey = await getSurveyById(parsed.surveyId);
+  if (!survey) {
+    throw new ApiError(404, "问卷不存在");
+  }
+
+  await updateTemplateRepo(id, {
+    name: parsed.name,
+    description: parsed.description ?? null,
+    surveyId: parsed.surveyId,
+    anonymityThreshold: parsed.anonymityThreshold,
+    relationshipRules: JSON.stringify(parsed.relationshipRules),
+    timeRule: JSON.stringify(parsed.timeRule),
+  });
+
+  const row = await findEvaluationTemplateById(id);
+  return parseTemplateRow(row!) as EvaluationTemplate;
+}
+
+export async function archiveEvaluationTemplate(id: number): Promise<void> {
+  const existing = await findEvaluationTemplateById(id);
+  if (!existing) {
+    throw new ApiError(404, "模板不存在");
+  }
+  if (existing.isBuiltin) {
+    throw new ApiError(403, "系统内置模板不能归档");
+  }
+  await archiveTemplateRepo(id);
+}
+
+export async function cloneEvaluationTemplate(id: number): Promise<EvaluationTemplate> {
+  const existing = await getEvaluationTemplateById(id);
+  if (!existing) {
+    throw new ApiError(404, "模板不存在");
+  }
+
+  return createEvaluationTemplate({
+    name: `${existing.name} 副本`,
+    description: existing.description,
+    surveyId: existing.surveyId,
+    anonymityThreshold: existing.anonymityThreshold,
+    relationshipRules: existing.relationshipRules,
+    timeRule: existing.timeRule,
+  });
+}

--- a/lib/evaluations/template-types.ts
+++ b/lib/evaluations/template-types.ts
@@ -1,0 +1,38 @@
+import type { EvaluationRelationship } from "./types";
+
+export type TemplateStatus = "active" | "archived";
+
+export type RelationshipRule = {
+  type: EvaluationRelationship;
+  count: number;
+  required: boolean;
+};
+
+export type TimeRule = {
+  type: "relative";
+  durationDays: number;
+};
+
+export type EvaluationTemplateInput = {
+  name: string;
+  description?: string | null;
+  surveyId: number;
+  anonymityThreshold: number;
+  relationshipRules: RelationshipRule[];
+  timeRule: TimeRule;
+};
+
+export type EvaluationTemplate = {
+  id: number;
+  name: string;
+  description: string | null;
+  surveyId: number;
+  anonymityThreshold: number;
+  relationshipRules: RelationshipRule[];
+  timeRule: TimeRule;
+  isBuiltin: boolean;
+  createdBy: number | null;
+  status: TemplateStatus;
+  createdAt: number;
+  updatedAt: number;
+};

--- a/lib/evaluations/template-validators.ts
+++ b/lib/evaluations/template-validators.ts
@@ -1,0 +1,28 @@
+import { z } from "zod";
+
+const relationshipRuleSchema = z.object({
+  type: z.enum(["self", "manager", "peer", "direct_report", "other"]),
+  count: z.number().int().min(0).max(50),
+  required: z.boolean(),
+});
+
+const timeRuleSchema = z.object({
+  type: z.literal("relative"),
+  durationDays: z.number().int().min(1).max(365),
+});
+
+export const evaluationTemplateInputSchema = z.object({
+  name: z.string().trim().min(1, "模板名称不能为空"),
+  description: z.string().trim().optional().nullable(),
+  surveyId: z.number().int().positive(),
+  anonymityThreshold: z.number().int().min(1).max(20),
+  relationshipRules: z.array(relationshipRuleSchema).min(1, "至少需要一条关系规则"),
+  timeRule: timeRuleSchema,
+});
+
+export const evaluationTemplateQuerySchema = z.object({
+  builtin: z
+    .enum(["true", "false"])
+    .optional()
+    .transform((v) => (v === undefined ? undefined : v === "true")),
+});

--- a/lib/evaluations/types.ts
+++ b/lib/evaluations/types.ts
@@ -15,6 +15,7 @@ export type EvaluationCycleInput = {
   startsAt?: number | null;
   endsAt?: number | null;
   anonymityThreshold?: number;
+  templateId?: number | null;
 };
 
 export type EvaluationAssignmentInput = {

--- a/lib/evaluations/validators.ts
+++ b/lib/evaluations/validators.ts
@@ -6,7 +6,8 @@ export const evaluationCycleInputSchema = z.object({
   surveyId: z.number().int().positive(),
   startsAt: z.number().int().nullable().optional(),
   endsAt: z.number().int().nullable().optional(),
-  anonymityThreshold: z.number().int().min(2).max(10).optional(),
+  anonymityThreshold: z.number().int().min(1).max(20).optional(),
+  templateId: z.number().int().positive().nullable().optional(),
 });
 
 export const evaluationAssignmentInputSchema = z.object({

--- a/lib/http/responses.ts
+++ b/lib/http/responses.ts
@@ -10,6 +10,10 @@ export function created<T>(data: T) {
   return NextResponse.json({ data }, { status: 201 });
 }
 
+export function noContent() {
+  return new NextResponse(null, { status: 204 });
+}
+
 export function fromError(error: unknown) {
   if (error instanceof ApiError) {
     return NextResponse.json(

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,5 @@
+packages:
+  - "."
 ignoredBuiltDependencies:
   - sharp
   - unrs-resolver

--- a/tests/e2e/evaluation-template.spec.ts
+++ b/tests/e2e/evaluation-template.spec.ts
@@ -1,0 +1,44 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("evaluation templates", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/login");
+    await page.fill('input[name="email"]', "admin@example.com");
+    await page.fill('input[name="password"]', "password");
+    await page.click('button[type="submit"]');
+    await page.waitForURL("/");
+  });
+
+  test("should create and use a template", async ({ page }) => {
+    // 1. Create a survey
+    await page.goto("/surveys/new");
+    await page.fill('input[name="title"]', "360 E2E Test Survey");
+    await page.click('button[type="submit"]');
+    await page.waitForURL(/\/surveys\/\d+/);
+    const surveyUrl = page.url();
+    const surveyId = Number(surveyUrl.match(/\/surveys\/(\d+)/)![1]);
+
+    // 2. Create a template
+    await page.goto("/evaluations/templates/new");
+    await page.fill('input[id="name"]', "E2E Test Template");
+    await page.fill('input[id="survey-id"]', surveyId.toString());
+    await page.click('button[type="submit"]');
+    await page.waitForURL("/evaluations/templates");
+    await expect(page.locator("text=E2E Test Template")).toBeVisible();
+
+    // 3. Clone the template
+    await page.click('button[title="克隆"]');
+    await expect(page.locator("text=E2E Test Template 副本")).toBeVisible();
+
+    // 4. Use template to create a cycle
+    await page.goto("/evaluations/new");
+    await page.click('[placeholder="选择模板（可选）"]');
+    await page.click('text=E2E Test Template');
+    await expect(page.locator('input[id="title"]')).toHaveValue(/E2E Test Template/);
+
+    // 5. Submit and verify
+    await page.click('button[type="submit"]');
+    await page.waitForURL(/\/evaluations\/\d+/);
+    await expect(page.locator("text=基于模板创建")).toBeVisible();
+  });
+});

--- a/tests/helpers/reset-db.ts
+++ b/tests/helpers/reset-db.ts
@@ -5,6 +5,7 @@ export function resetDatabase() {
     DELETE FROM evaluation_assignments;
     DELETE FROM evaluation_subjects;
     DELETE FROM evaluation_cycles;
+    DELETE FROM evaluation_templates;
     DELETE FROM employees;
     DELETE FROM survey_options;
     DELETE FROM survey_questions;

--- a/tests/lib/evaluations/service.test.ts
+++ b/tests/lib/evaluations/service.test.ts
@@ -168,3 +168,79 @@ describe("evaluation service", () => {
     ).rejects.toThrow("该评价任务已完成");
   });
 });
+
+import { createEvaluationTemplate } from "@/lib/evaluations/template-service";
+
+describe("create cycle from template", () => {
+  beforeEach(() => {
+    resetDatabase();
+  });
+
+  it("should create cycle with templateId", async () => {
+    const survey = await createSurvey({
+      title: "360 评价表",
+      questions: [
+        {
+          type: "rating",
+          title: "沟通协作",
+          required: true,
+          orderIndex: 0,
+          config: { maxRating: 5 },
+          options: [],
+        },
+      ],
+    });
+
+    const template = await createEvaluationTemplate({
+      name: "季度 360",
+      surveyId: survey.id,
+      anonymityThreshold: 5,
+      relationshipRules: [{ type: "self", count: 1, required: true }],
+      timeRule: { type: "relative", durationDays: 14 },
+    });
+
+    const cycle = await createEvaluationCycle({
+      title: "2026 Q2",
+      surveyId: survey.id,
+      templateId: template.id,
+    });
+
+    expect(cycle.templateId).toBe(template.id);
+  });
+
+  it("should reject inactive template", async () => {
+    const survey = await createSurvey({
+      title: "360 评价表",
+      questions: [
+        {
+          type: "rating",
+          title: "沟通协作",
+          required: true,
+          orderIndex: 0,
+          config: { maxRating: 5 },
+          options: [],
+        },
+      ],
+    });
+
+    const template = await createEvaluationTemplate({
+      name: "季度 360",
+      surveyId: survey.id,
+      anonymityThreshold: 5,
+      relationshipRules: [{ type: "self", count: 1, required: true }],
+      timeRule: { type: "relative", durationDays: 14 },
+    });
+
+    // Archive the template
+    const { archiveEvaluationTemplate } = await import("@/lib/evaluations/template-service");
+    await archiveEvaluationTemplate(template.id);
+
+    await expect(
+      createEvaluationCycle({
+        title: "2026 Q2",
+        surveyId: survey.id,
+        templateId: template.id,
+      })
+    ).rejects.toThrow("模板不存在或已归档");
+  });
+});

--- a/tests/lib/evaluations/template-repository.test.ts
+++ b/tests/lib/evaluations/template-repository.test.ts
@@ -1,0 +1,161 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { db } from "@/lib/db/client";
+import { surveys } from "@/lib/db/schema";
+import {
+  archiveEvaluationTemplate,
+  findEvaluationTemplateById,
+  insertEvaluationTemplate,
+  listEvaluationTemplates,
+  updateEvaluationTemplate,
+} from "@/lib/evaluations/template-repository";
+import { resetDatabase } from "@/tests/helpers/reset-db";
+
+function createSurvey() {
+  const result = db
+    .insert(surveys)
+    .values({
+      title: "测试问卷",
+      status: "published",
+      createdAt: Math.floor(Date.now() / 1000),
+      updatedAt: Math.floor(Date.now() / 1000),
+    })
+    .run();
+  return Number(result.lastInsertRowid);
+}
+
+describe("template repository", () => {
+  beforeEach(() => {
+    resetDatabase();
+  });
+
+  it("should insert and find a template", async () => {
+    const surveyId = createSurvey();
+    const id = await insertEvaluationTemplate({
+      name: "季度 360",
+      description: "季度员工评价",
+      surveyId,
+      anonymityThreshold: 3,
+      relationshipRules: JSON.stringify([{ type: "self", count: 1, required: true }]),
+      timeRule: JSON.stringify({ type: "relative", durationDays: 14 }),
+      isBuiltin: false,
+      createdBy: null,
+    });
+
+    const found = await findEvaluationTemplateById(id);
+    expect(found).not.toBeNull();
+    expect(found!.name).toBe("季度 360");
+  });
+
+  it("should list active templates", async () => {
+    const surveyId = createSurvey();
+    await insertEvaluationTemplate({
+      name: "T1",
+      description: null,
+      surveyId,
+      anonymityThreshold: 3,
+      relationshipRules: "[]",
+      timeRule: JSON.stringify({ type: "relative", durationDays: 14 }),
+      isBuiltin: true,
+      createdBy: null,
+    });
+
+    const list = await listEvaluationTemplates();
+    expect(list).toHaveLength(1);
+  });
+
+  it("should filter templates by builtin", async () => {
+    const surveyId = createSurvey();
+    await insertEvaluationTemplate({
+      name: "Builtin",
+      description: null,
+      surveyId,
+      anonymityThreshold: 3,
+      relationshipRules: "[]",
+      timeRule: JSON.stringify({ type: "relative", durationDays: 14 }),
+      isBuiltin: true,
+      createdBy: null,
+    });
+    await insertEvaluationTemplate({
+      name: "Custom",
+      description: null,
+      surveyId,
+      anonymityThreshold: 3,
+      relationshipRules: "[]",
+      timeRule: JSON.stringify({ type: "relative", durationDays: 14 }),
+      isBuiltin: false,
+      createdBy: null,
+    });
+
+    const builtinList = await listEvaluationTemplates({ builtin: true });
+    expect(builtinList).toHaveLength(1);
+    expect(builtinList[0].name).toBe("Builtin");
+
+    const customList = await listEvaluationTemplates({ builtin: false });
+    expect(customList).toHaveLength(1);
+    expect(customList[0].name).toBe("Custom");
+  });
+
+  it("should update a template", async () => {
+    const surveyId = createSurvey();
+    const id = await insertEvaluationTemplate({
+      name: "T1",
+      description: null,
+      surveyId,
+      anonymityThreshold: 3,
+      relationshipRules: "[]",
+      timeRule: JSON.stringify({ type: "relative", durationDays: 14 }),
+      isBuiltin: false,
+      createdBy: null,
+    });
+
+    await updateEvaluationTemplate(id, {
+      name: "T1 Updated",
+      description: "Updated desc",
+      surveyId,
+      anonymityThreshold: 5,
+      relationshipRules: "[]",
+      timeRule: JSON.stringify({ type: "relative", durationDays: 21 }),
+    });
+
+    const found = await findEvaluationTemplateById(id);
+    expect(found!.name).toBe("T1 Updated");
+    expect(found!.anonymityThreshold).toBe(5);
+  });
+
+  it("should archive a template", async () => {
+    const surveyId = createSurvey();
+    const id = await insertEvaluationTemplate({
+      name: "T1",
+      description: null,
+      surveyId,
+      anonymityThreshold: 3,
+      relationshipRules: "[]",
+      timeRule: JSON.stringify({ type: "relative", durationDays: 14 }),
+      isBuiltin: false,
+      createdBy: null,
+    });
+
+    await archiveEvaluationTemplate(id);
+    const found = await findEvaluationTemplateById(id);
+    expect(found!.status).toBe("archived");
+  });
+
+  it("should not list archived templates", async () => {
+    const surveyId = createSurvey();
+    const id = await insertEvaluationTemplate({
+      name: "T1",
+      description: null,
+      surveyId,
+      anonymityThreshold: 3,
+      relationshipRules: "[]",
+      timeRule: JSON.stringify({ type: "relative", durationDays: 14 }),
+      isBuiltin: false,
+      createdBy: null,
+    });
+
+    await archiveEvaluationTemplate(id);
+    const list = await listEvaluationTemplates();
+    expect(list).toHaveLength(0);
+  });
+});

--- a/tests/lib/evaluations/template-service.test.ts
+++ b/tests/lib/evaluations/template-service.test.ts
@@ -1,0 +1,145 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import {
+  archiveEvaluationTemplate,
+  cloneEvaluationTemplate,
+  createEvaluationTemplate,
+  getEvaluationTemplateById,
+  listEvaluationTemplates,
+  updateEvaluationTemplate,
+} from "@/lib/evaluations/template-service";
+import { createSurvey } from "@/lib/surveys/service";
+import { resetDatabase } from "@/tests/helpers/reset-db";
+
+async function makeSurvey() {
+  return createSurvey({
+    title: "360 评价表",
+    questions: [
+      {
+        type: "rating",
+        title: "沟通协作",
+        required: true,
+        orderIndex: 0,
+        config: { maxRating: 5 },
+        options: [],
+      },
+    ],
+  });
+}
+
+describe("template service", () => {
+  beforeEach(() => {
+    resetDatabase();
+  });
+
+  it("should create a template", async () => {
+    const survey = await makeSurvey();
+    const template = await createEvaluationTemplate({
+      name: "季度 360",
+      surveyId: survey.id,
+      anonymityThreshold: 3,
+      relationshipRules: [{ type: "self", count: 1, required: true }],
+      timeRule: { type: "relative", durationDays: 14 },
+    });
+
+    expect(template.name).toBe("季度 360");
+    expect(template.relationshipRules).toEqual([{ type: "self", count: 1, required: true }]);
+    expect(template.isBuiltin).toBe(false);
+  });
+
+  it("should get template by id", async () => {
+    const survey = await makeSurvey();
+    const created = await createEvaluationTemplate({
+      name: "季度 360",
+      surveyId: survey.id,
+      anonymityThreshold: 3,
+      relationshipRules: [{ type: "self", count: 1, required: true }],
+      timeRule: { type: "relative", durationDays: 14 },
+    });
+
+    const found = await getEvaluationTemplateById(created.id);
+    expect(found).not.toBeNull();
+    expect(found!.name).toBe("季度 360");
+  });
+
+  it("should list templates", async () => {
+    const survey = await makeSurvey();
+    await createEvaluationTemplate({
+      name: "T1",
+      surveyId: survey.id,
+      anonymityThreshold: 3,
+      relationshipRules: [{ type: "self", count: 1, required: true }],
+      timeRule: { type: "relative", durationDays: 14 },
+    });
+
+    const list = await listEvaluationTemplates();
+    expect(list).toHaveLength(1);
+  });
+
+  it("should clone a template", async () => {
+    const survey = await makeSurvey();
+    const original = await createEvaluationTemplate({
+      name: "季度 360",
+      surveyId: survey.id,
+      anonymityThreshold: 3,
+      relationshipRules: [{ type: "self", count: 1, required: true }],
+      timeRule: { type: "relative", durationDays: 14 },
+    });
+
+    const clone = await cloneEvaluationTemplate(original.id);
+    expect(clone.name).toBe("季度 360 副本");
+    expect(clone.surveyId).toBe(original.surveyId);
+    expect(clone.isBuiltin).toBe(false);
+  });
+
+  it("should reject updating a builtin template", async () => {
+    const survey = await makeSurvey();
+    const template = await createEvaluationTemplate({
+      name: "系统模板",
+      surveyId: survey.id,
+      anonymityThreshold: 3,
+      relationshipRules: [{ type: "self", count: 1, required: true }],
+      timeRule: { type: "relative", durationDays: 14 },
+      isBuiltin: true,
+    });
+
+    await expect(
+      updateEvaluationTemplate(template.id, {
+        name: "改名",
+        surveyId: survey.id,
+        anonymityThreshold: 3,
+        relationshipRules: [{ type: "self", count: 1, required: true }],
+        timeRule: { type: "relative", durationDays: 14 },
+      })
+    ).rejects.toThrow("系统内置模板不能编辑");
+  });
+
+  it("should archive a custom template", async () => {
+    const survey = await makeSurvey();
+    const template = await createEvaluationTemplate({
+      name: "季度 360",
+      surveyId: survey.id,
+      anonymityThreshold: 3,
+      relationshipRules: [{ type: "self", count: 1, required: true }],
+      timeRule: { type: "relative", durationDays: 14 },
+    });
+
+    await archiveEvaluationTemplate(template.id);
+    const found = await getEvaluationTemplateById(template.id);
+    expect(found!.status).toBe("archived");
+  });
+
+  it("should reject archiving a builtin template", async () => {
+    const survey = await makeSurvey();
+    const template = await createEvaluationTemplate({
+      name: "系统模板",
+      surveyId: survey.id,
+      anonymityThreshold: 3,
+      relationshipRules: [{ type: "self", count: 1, required: true }],
+      timeRule: { type: "relative", durationDays: 14 },
+      isBuiltin: true,
+    });
+
+    await expect(archiveEvaluationTemplate(template.id)).rejects.toThrow("系统内置模板不能归档");
+  });
+});


### PR DESCRIPTION
Closes #15

## Summary
实现 360 环评模板系统，支持系统内置模板和管理员自定义模板，创建评价周期时可选择模板自动回填配置。

## Changes
- 新增 `evaluation_templates` 表，为 `evaluation_cycles` 添加 `template_id` 溯源字段
- 模板 CRUD Service + Repository（含克隆、归档、内置模板保护）
- 模板管理 REST API（GET / POST / PUT / DELETE / clone）
- 创建周期页集成模板选择器，自动回填问卷/阈值/时间
- 周期详情页显示「基于模板创建」溯源标签
- 匿名阈值字段增加说明文案

## Test Plan
- [x] `tests/lib/evaluations/template-repository.test.ts` — 6 passed
- [x] `tests/lib/evaluations/template-service.test.ts` — 7 passed
- [x] `tests/lib/evaluations/service.test.ts` — 全量通过（含模板关联周期创建）
- [x] 总测试数：26/26 passed